### PR TITLE
UseAddon: use profile-derived list of implicit USE flags

### DIFF
--- a/pkgcheck/addons.py
+++ b/pkgcheck/addons.py
@@ -462,26 +462,37 @@ class UnstatedIUSE(base.Error):
 
 class UseAddon(base.Addon):
 
+    required_addons = (ProfileAddon,)
     known_results = (UnstatedIUSE,)
 
-    def __init__(self, options, silence_warnings=False):
+    def __init__(self, options, profiles, silence_warnings=False):
         base.Addon.__init__(self, options)
+
+        # common profile elements
+        c_implicit_iuse = None
+
+        for key, profiles in profiles.profile_filters.iteritems():
+            if key.startswith("-"):
+                continue
+            for p in profiles:
+                if c_implicit_iuse is None:
+                    c_implicit_iuse = set(p.iuse_effective)
+                else:
+                    c_implicit_iuse.intersection_update(p.iuse_effective)
+
         known_iuse = set()
-        unstated_iuse = set()
-        arches = set()
+        known_iuse_expand = set()
 
         known_iuse.update(x[1][0] for x in options.target_repo.config.use_desc)
-        arches.update(options.target_repo.config.known_arches)
-        unstated_iuse.update(x[1][0] for x in options.target_repo.config.use_expand_desc)
+        known_iuse_expand.update(x[1][0] for x in options.target_repo.config.use_expand_desc)
 
         self.collapsed_iuse = misc.non_incremental_collapsed_restrict_to_data(
             ((packages.AlwaysTrue, known_iuse),),
-            ((packages.AlwaysTrue, unstated_iuse),),
+            ((packages.AlwaysTrue, known_iuse_expand),),
         )
-        self.global_iuse = frozenset(known_iuse)
-        unstated_iuse.update(arches)
-        self.unstated_iuse = frozenset(unstated_iuse)
-        self.ignore = not (unstated_iuse or known_iuse)
+        self.global_iuse = frozenset(known_iuse | known_iuse_expand)
+        self.unstated_iuse = frozenset(c_implicit_iuse)
+        self.ignore = not (c_implicit_iuse or known_iuse or known_iuse_expand)
         if self.ignore and not silence_warnings:
             logger.warn('disabling use/iuse validity checks since no usable '
                         'use.desc, use.local.desc were found ')
@@ -514,10 +525,7 @@ class UseAddon(base.Addon):
                 continue
             yield node
 
-        # the valid_unstated_iuse filters out USE_EXPAND as long as
-        # it's listed in a desc file
+        # implicit IUSE flags
         unstated.difference_update(self.unstated_iuse)
-        # hack, see bugs.gentoo.org 134994; same goes for prefix
-        unstated.difference_update(["bootstrap", "prefix"])
         if unstated:
             reporter.add_report(UnstatedIUSE(pkg, attr, unstated))

--- a/pkgcheck/repo_metadata.py
+++ b/pkgcheck/repo_metadata.py
@@ -51,7 +51,7 @@ class UnusedGlobalFlags(base.Template):
 
     def start(self):
         if not isinstance(self.options.target_repo, SlavedTree):
-            self.flags = set(self.iuse_handler.global_iuse)
+            self.flags = set(self.iuse_handler.global_iuse - self.iuse_handler.unstated_iuse)
 
     def feed(self, pkg, reporter):
         if self.flags:


### PR DESCRIPTION
Use profile-derived list of implicit USE flags (that follows either EAPI
5 or hacky logic for earlier EAPIs) rather than the pre-EAPI 5 hardcoded
logic used so far.

This improves unused global USE flag check to include unused USE_EXPAND
flags. It also triggers on supposedly-implicit USE_EXPAND flags that are
not in USE_EXPAND_VALUES_*.

It may be a good idea to split the report in the future, to include
separately: unused global USE flags, unused (whole) USE_EXPANDs, unused
USE_EXPAND flags and missing USE_EXPAND_VALUES_*.

-------

Note: global CI run not done yet. I'm curious as to result due to the mint profile-induced breakage.