### PR TITLE
Fixes to Manifest checks

### DIFF
--- a/pkgcheck/repo_metadata.py
+++ b/pkgcheck/repo_metadata.py
@@ -571,7 +571,8 @@ class ManifestReport(base.Template):
                     seen.add(f_inst.filename)
                     existing = self.seen_checksums.get(f_inst.filename)
                     if existing is None:
-                        existing = ([pkg], dict(f_inst.chksums.iteritems()))
+                        self.seen_checksums[f_inst.filename] = (
+                                [pkg], dict(f_inst.chksums.iteritems()))
                         continue
                     seen_pkgs, seen_chksums = existing
                     for chf_type, value in seen_chksums.iteritems():

--- a/pkgcheck/repo_metadata.py
+++ b/pkgcheck/repo_metadata.py
@@ -527,7 +527,8 @@ class ManifestReport(base.Template):
 
     required_addons = (addons.UseAddon,)
     feed_type = base.package_feed
-    known_results = (MissingChksum, MissingManifest, UnknownManifest, UnnecessaryManifest)
+    known_results = (MissingChksum, MissingManifest, UnknownManifest, UnnecessaryManifest,
+                     ConflictingChksums)
 
     repo_grabber = attrgetter("repo")
 

--- a/pkgcheck/repo_metadata.py
+++ b/pkgcheck/repo_metadata.py
@@ -572,15 +572,17 @@ class ManifestReport(base.Template):
                     existing = self.seen_checksums.get(f_inst.filename)
                     if existing is None:
                         self.seen_checksums[f_inst.filename] = (
-                                [pkg], dict(f_inst.chksums.iteritems()))
+                                [pkg.key], dict(f_inst.chksums.iteritems()))
                         continue
                     seen_pkgs, seen_chksums = existing
+                    confl_checksums = []
                     for chf_type, value in seen_chksums.iteritems():
                         our_value = f_inst.chksums.get(chf_type)
                         if our_value is not None and our_value != value:
-                            reporter.add_result(ConflictingChksums(
-                                pkg, f_inst.filename, f_inst.chksums, seen_chksums))
-                            break
+                            confl_checksums.append((chf_type, value, our_value))
+                    if confl_checksums:
+                        reporter.add_report(ConflictingChksums(
+                            pkg, f_inst.filename, confl_checksums, seen_pkgs))
                     else:
                         seen_chksums.update(f_inst.chksums)
                         seen_pkgs.append(pkg)


### PR DESCRIPTION
Fix a few solid bugs in Manifest checks that prevented conflicting checksum check from being run, then fix the check to not explode when trying to report.
