### PR TITLE
GLEP73 REQUIRED_USE GLEP checks

### DIFF
--- a/src/pkgcheck/glep73.py
+++ b/src/pkgcheck/glep73.py
@@ -35,23 +35,23 @@ class GLEP73Immutability(base.Error):
     unsolvable requests."""
 
     __slots__ = ("category", "package", "version", "condition",
-                 "enforcement", "profiles")
+                 "enforcement", "profile")
     threshold = base.versioned_feed
 
-    def __init__(self, pkg, condition, enforcement, profiles):
+    def __init__(self, pkg, condition, enforcement, profile):
         super(GLEP73Immutability, self).__init__()
         self._store_cpv(pkg)
         self.condition = condition
         self.enforcement = enforcement
-        self.profiles = profiles
+        self.profile = profile
 
     @property
     def short_desc(self):
         return ('REQUIRED_USE violates immutability rules: ' +
                 '[%s] requires [%s] while the opposite value is ' +
-                'enforced by use.force/mask (in profiles: %s)') % (
+                'enforced by use.force/mask (in profile: %s)') % (
                 ' && '.join('%s' % x for x in self.condition),
-                self.enforcement, self.profiles)
+                self.enforcement, self.profile)
 
 
 class GLEP73SelfConflicting(base.Warning):
@@ -60,16 +60,16 @@ class GLEP73SelfConflicting(base.Warning):
     and our algorithms do not take it into consideration."""
 
     __slots__ = ("category", "package", "version", "condition",
-                 "enforcement", "flag", "profiles")
+                 "enforcement", "flag", "profile")
     threshold = base.versioned_feed
 
-    def __init__(self, pkg, condition, enforcement, flag, profiles):
+    def __init__(self, pkg, condition, enforcement, flag, profile):
         super(GLEP73SelfConflicting, self).__init__()
         self._store_cpv(pkg)
         self.condition = condition
         self.enforcement = enforcement
         self.flag = flag
-        self.profiles = profiles
+        self.profile = profile
 
     @property
     def short_desc(self):
@@ -88,17 +88,17 @@ class GLEP73Conflict(base.Warning):
     messages for regular users."""
 
     __slots__ = ("category", "package", "version", "ci", "ei",
-                 "cj", "ej", "profiles")
+                 "cj", "ej", "profile")
     threshold = base.versioned_feed
 
-    def __init__(self, pkg, ci, ei, cj, ej, profiles):
+    def __init__(self, pkg, ci, ei, cj, ej, profile):
         super(GLEP73Conflict, self).__init__()
         self._store_cpv(pkg)
         self.ci = ci
         self.ei = ei
         self.cj = cj
         self.ej = ej
-        self.profiles = profiles
+        self.profile = profile
 
     @property
     def short_desc(self):
@@ -115,17 +115,17 @@ class GLEP73BackAlteration(base.Warning):
     iterations in order to enforce the constraints."""
 
     __slots__ = ("category", "package", "version", "ci", "ei",
-                 "cj", "ej", "profiles")
+                 "cj", "ej", "profile")
     threshold = base.versioned_feed
 
-    def __init__(self, pkg, ci, ei, cj, ej, profiles):
+    def __init__(self, pkg, ci, ei, cj, ej, profile):
         super(GLEP73BackAlteration, self).__init__()
         self._store_cpv(pkg)
         self.ci = ci
         self.ei = ei
         self.cj = cj
         self.ej = ej
-        self.profiles = profiles
+        self.profile = profile
 
     @property
     def short_desc(self):

--- a/src/pkgcheck/glep73.py
+++ b/src/pkgcheck/glep73.py
@@ -380,7 +380,7 @@ def glep73_run_checks(requse, immutables):
                               condition=ci,
                               enforcement=ei)
 
-        for cj, ej in flattened[i+1:]:
+        for j, (cj, ej) in enumerate(flattened[i+1:], i+1):
             cis, cjs = strip_common_prefix(ci, cj)
 
             # 2. conflict check:
@@ -388,6 +388,13 @@ def glep73_run_checks(requse, immutables):
             # a. Ei = !Ej, and
             # b. Ci and Cj can occur simultaneously.
             if ei == ej.negated() and conditions_can_coexist(cis, cjs):
-                yield partial(GLEP73Conflict,
-                              ci=ci, ei=ei,
-                              cj=cj, ej=ej)
+                # we presume both can only match simultaneously if Ci|Cj
+                common_cond = set(ci) | set(cj)
+                # check if common_cond does not make either of
+                # the conditions impossible
+                if (condition_can_occur(ci, flattened[:i], common_cond) and
+                    condition_can_occur(cj, flattened[:j], common_cond)):
+
+                    yield partial(GLEP73Conflict,
+                                  ci=ci, ei=ei,
+                                  cj=cj, ej=ej)

--- a/src/pkgcheck/glep73.py
+++ b/src/pkgcheck/glep73.py
@@ -352,6 +352,17 @@ def get_final_flags(constraints, initial_flags):
     return flag_states
 
 
+def condition_can_occur(final_condition, constraints, initial_flags):
+    """Returns true if final_condition can evaluate to true after
+    applying the specified initial flags and processing the constraints.
+    It is assumed that the condition can evaluate to true if the final
+    flags do not cause any of the subconditions to unconditionally
+    evaluate to false."""
+    return test_condition(final_condition,
+            get_final_flags(constraints, initial_flags),
+            True)
+
+
 def glep73_run_checks(requse, immutables):
     flattened = glep73_flatten(requse, immutables)
 

--- a/src/pkgcheck/glep73.py
+++ b/src/pkgcheck/glep73.py
@@ -443,6 +443,9 @@ def glep73_run_checks(requse, immutables):
             # 1. Ej is in the non-common part of Ci,
             # 2. Ci can occur simultaneously with Cj.
             if ej in cis and conditions_can_coexist(cis, cjs):
-                yield partial(GLEP73BackAlteration,
-                              ci=ci, ei=ei,
-                              cj=cj, ej=ej)
+                # check if Ei is not enforced by some other rule for Cj
+                # anyway
+                if not condition_always_occurs([ei], flattened, cj):
+                    yield partial(GLEP73BackAlteration,
+                                  ci=ci, ei=ei,
+                                  cj=cj, ej=ej)

--- a/src/pkgcheck/glep73.py
+++ b/src/pkgcheck/glep73.py
@@ -149,6 +149,10 @@ class GLEP73Flag(object):
             self.name = name_or_restriction
             self.enabled = not negate
 
+    def negated(self):
+        """Return the negated version of the flag."""
+        return GLEP73Flag(self.name, negate=self.enabled)
+
     def __eq__(self, other):
         return self.name == other.name and self.enabled == other.enabled
 
@@ -231,6 +235,17 @@ def glep73_flatten(requse, immutables={}):
                 raise AssertionError('Unknown item in REQUIRED_USE: %s' % (c,))
 
     return list(rec(requse, []))
+
+
+def conditions_can_coexist(c1, c2):
+    """Check whether the two conditions c1 and c2 can coexist, that is
+    whether they both can evaluate to true simultaneously. It is assumed
+    that this is true if the two conditions do not request the opposite
+    states of the same flag."""
+    for c1i in c1:
+        if c1i.negated() in c2:
+            return False
+    return True
 
 
 def glep73_run_checks(requse, immutables):

--- a/src/pkgcheck/glep73.py
+++ b/src/pkgcheck/glep73.py
@@ -277,6 +277,19 @@ def conditions_can_coexist(c1, c2):
     return True
 
 
+def strip_common_prefix(c1, c2):
+    """Check if the conditions of two flattened constraint share common
+    nodes on the condition graph. If they do, discard the common prefix
+    and return the tuple with unique node sets for both."""
+    # copy in order to avoid altering the original values
+    c1 = list(c1)
+    c2 = list(c2)
+    while c1 and c2 and c1[0] is c2[0]:
+        del c1[0]
+        del c2[0]
+    return (c1, c2)
+
+
 def glep73_run_checks(requse, immutables):
     flattened = glep73_flatten(requse, immutables)
 
@@ -295,11 +308,13 @@ def glep73_run_checks(requse, immutables):
                               enforcement=ei)
 
         for cj, ej in flattened[i+1:]:
+            cis, cjs = strip_common_prefix(ci, cj)
+
             # 2. conflict check:
             # two constraints (Ci, Ei); (Cj, Ej) conflict if:
             # a. Ei = !Ej, and
             # b. Ci and Cj can occur simultaneously.
-            if ei == ej.negated() and conditions_can_coexist(ci, cj):
+            if ei == ej.negated() and conditions_can_coexist(cis, cjs):
                 yield partial(GLEP73Conflict,
                               ci=ci, ei=ei,
                               cj=cj, ej=ej)

--- a/src/pkgcheck/glep73.py
+++ b/src/pkgcheck/glep73.py
@@ -290,6 +290,22 @@ def strip_common_prefix(c1, c2):
     return (c1, c2)
 
 
+def test_condition(c, flag_dict, accept_undefined):
+    """Test whether the set of conditions C evaluates to true, with flag
+    states defined by flag_dict (dict of flag name->bool). If the flag
+    is not included in flag_dict and accept_undefined is true, it is
+    assumed to match. If accept_undefined is false, it is assumed
+    not to match."""
+    for ci in c:
+        v = flag_dict.get(ci.name)
+        if v is None:
+            if not accept_undefined:
+                return False
+        elif v != ci.enabled:
+            return False
+    return True
+
+
 def glep73_run_checks(requse, immutables):
     flattened = glep73_flatten(requse, immutables)
 

--- a/src/pkgcheck/glep73.py
+++ b/src/pkgcheck/glep73.py
@@ -80,3 +80,71 @@ def glep73_validate_syntax(requse, reporter, pkg):
             raise AssertionError('Unknown item in REQUIRED_USE: %s' % (c,))
 
     return True
+
+
+class GLEP73Flag(object):
+    """A trivial holder for flag name+value inside flat constraints.
+    It replaces ContainmentMatch since the latter has instance caching
+    which breaks identity comparison."""
+
+    __slots__ = ('name', 'enabled')
+
+    def __init__(self, name_or_restriction, negate=False):
+        """Initialize either using a flag name (string) or
+        a ContainmentMatch restriction. The value will be negated
+        from the original if negate is True."""
+        if isinstance(name_or_restriction, ContainmentMatch):
+            assert(len(name_or_restriction.vals) == 1)
+            self.name = next(iter(name_or_restriction.vals))
+            # name_or_restriction.negate XOR negate
+            self.enabled = (name_or_restriction.negate == negate)
+        else:
+            self.name = name_or_restriction
+            self.enabled = not negate
+
+    def __eq__(self, other):
+        return self.name == other.name and self.enabled == other.enabled
+
+    def __hash__(self):
+        return hash((self.name, self.enabled))
+
+    def __str__(self):
+        return '%s%s' % ('' if self.enabled else '!', self.name)
+
+    def __repr__(self):
+        return 'GLEP73Flag("%s", negate=%s)' % (self.name, not self.enabled)
+
+
+def glep73_flatten(requse):
+    """Transform the REQUIRED_USE into flat constraints as described
+    in GLEP 73."""
+    def rec(restrictions, conditions):
+        for c in restrictions:
+            if isinstance(c, ContainmentMatch):
+                # plain flag
+                yield (conditions, GLEP73Flag(c))
+            elif isinstance(c, Conditional):
+                assert(c.attr == 'use')
+                assert(isinstance(c.restriction, ContainmentMatch))
+                # recurse on conditionals
+                for x in rec(c, conditions+[GLEP73Flag(c.restriction)]):
+                    yield x
+            elif (isinstance(c, OrRestriction) or
+                  isinstance(c, JustOneRestriction) or
+                  isinstance(c, AtMostOneOfRestriction)):
+                if not isinstance(c, AtMostOneOfRestriction):
+                    # ^^ ( a b c ... ) -> || ( a b c ) ...
+                    # || ( a b c ... ) -> [!b !c ...]? ( a )
+                    yield (conditions + [GLEP73Flag(x, negate=True) for x in c.restrictions[1:]],
+                           GLEP73Flag(c.restrictions[0]))
+                if not isinstance(c, OrRestriction):
+                    # ^^ ( a b c ... ) -> ... ?? ( a b c )
+                    # ?? ( a b c ... ) -> a? ( !b !c ... ) b? ( !c ... ) ...
+                    for i in range(0, len(c.restrictions)-1):
+                        new_cond = conditions + [GLEP73Flag(x) for x in c.restrictions[i:i+1]]
+                        for x in c.restrictions[i+1:]:
+                            yield (new_cond, GLEP73Flag(x, negate=True))
+            else:
+                raise AssertionError('Unknown item in REQUIRED_USE: %s' % (c,))
+
+    return list(rec(requse, []))

--- a/src/pkgcheck/glep73.py
+++ b/src/pkgcheck/glep73.py
@@ -391,6 +391,17 @@ def condition_can_occur(final_condition, constraints, initial_flags):
             True)
 
 
+def condition_always_occurs(final_condition, constraints, initial_flags):
+    """Returns true if final_condition always evaluates to true after
+    applying the specified initial flags and processing the constraints.
+    It is assumed that the condition always evaluates to true
+    if the final flags match all the sub-conditions of the final
+    condition explicitly."""
+    return test_condition(final_condition,
+            get_final_flags(constraints, initial_flags),
+            False)
+
+
 def glep73_run_checks(requse, immutables):
     flattened = glep73_flatten(requse, immutables)
 

--- a/src/pkgcheck/glep73.py
+++ b/src/pkgcheck/glep73.py
@@ -1,0 +1,82 @@
+from pkgcore.restrictions.boolean import (OrRestriction, AndRestriction,
+        JustOneRestriction, AtMostOneOfRestriction)
+from pkgcore.restrictions.packages import Conditional
+from pkgcore.restrictions.values import ContainmentMatch
+
+from pkgcheck import base
+
+
+class GLEP73Syntax(base.Warning):
+    """REQUIRED_USE constraints whose syntax violates the restrictions
+    set in GLEP 73. They are complex or otherwise potentially surprising
+    and can be easily replaced by more readable constructs."""
+
+    __slots__ = ("category", "package", "version", "required_use", "issue")
+    threshold = base.versioned_feed
+
+    def __init__(self, pkg, required_use, issue):
+        super(GLEP73Syntax, self).__init__()
+        self._store_cpv(pkg)
+        self.required_use = required_use
+        self.issue = issue
+
+    @property
+    def short_desc(self):
+        return 'REQUIRED_USE syntax violates GLEP 73: %s (in %s)' % (
+                self.issue, self.required_use)
+
+
+glep73_known_results = (GLEP73Syntax,)
+
+
+def group_name(c):
+    """Return a user-friendly name of the specific restriction."""
+    if isinstance(c, OrRestriction):
+        return 'any-of'
+    elif isinstance(c, JustOneRestriction):
+        return 'exactly-one-of'
+    elif isinstance(c, AtMostOneOfRestriction):
+        return 'at-most-one-of'
+    elif isinstance(c, AndRestriction):
+        return 'all-of'
+    elif isinstance(c, Conditional):
+        return 'USE-conditional'
+    else:
+        raise AssertionError('Unexpected type in group_name(): %s' % (c,))
+
+
+def glep73_validate_syntax(requse, reporter, pkg):
+    """Validate whether the REQUIRED_USE constraint matches the syntax
+    restrictions in GLEP 73, i.e. does not contain all-of groups
+    and ||/??/^^ groups are flat and non-empty."""
+    for c in requse:
+        if isinstance(c, AndRestriction):
+            # TODO: pkgcore normalizes nested meaningless and-of groups
+            # figure out how to detect them
+            reporter.add_report(GLEP73Syntax(
+                pkg, pkg.required_use, 'all-of groups are forbidden'))
+            return False
+        elif (isinstance(c, OrRestriction) or
+              isinstance(c, JustOneRestriction) or
+              isinstance(c, AtMostOneOfRestriction)):
+            # ||/^^/?? can contain only flat flags -- nesting is forbidden
+            for f in c:
+                if not isinstance(f, ContainmentMatch):
+                    reporter.add_report(GLEP73Syntax(
+                        pkg, pkg.required_use, 'nesting %s inside %s is forbidden'
+                        % (group_name(f), group_name(c))))
+                    return False
+            if len(c) == 0:
+                # pkgcheck already reports empty groups, so just return False
+                return False
+        elif isinstance(c, Conditional):
+            # recurse on conditionals
+            if not glep73_validate_syntax(c, reporter, pkg):
+                return False
+        elif isinstance(c, ContainmentMatch):
+            # plain flag
+            pass
+        else:
+            raise AssertionError('Unknown item in REQUIRED_USE: %s' % (c,))
+
+    return True

--- a/src/pkgcheck/glep73.py
+++ b/src/pkgcheck/glep73.py
@@ -110,6 +110,25 @@ def glep73_validate_syntax(requse, reporter, pkg):
     return True
 
 
+def glep73_get_all_flags(requse):
+    """Grab names of all flags used in the REQUIRED_USE constraint."""
+    ret = set()
+    for c in requse:
+        if isinstance(c, ContainmentMatch):
+            ret.update(c.vals)
+        elif isinstance(c, Conditional):
+            ret.update(glep73_get_all_flags(c))
+            ret.update(glep73_get_all_flags((c.restriction,)))
+        elif (isinstance(c, OrRestriction) or
+              isinstance(c, JustOneRestriction) or
+              isinstance(c, AtMostOneOfRestriction)):
+            ret.update(glep73_get_all_flags(c))
+        else:
+            raise AssertionError('Unexpected item in REQUIRED_USE: %s' % (c,))
+
+    return ret
+
+
 class GLEP73Flag(object):
     """A trivial holder for flag name+value inside flat constraints.
     It replaces ContainmentMatch since the latter has instance caching

--- a/src/pkgcheck/metadata_checks.py
+++ b/src/pkgcheck/metadata_checks.py
@@ -11,6 +11,7 @@ from snakeoil.sequences import iflatten_instance
 from snakeoil.strings import pluralism
 
 from . import base, addons
+from .glep73 import glep73_validate_syntax, glep73_known_results
 from .visibility import FakeConfigurable
 
 demandload('logging')
@@ -138,7 +139,8 @@ class RequiredUSEMetadataReport(base.Template):
 
     feed_type = base.versioned_feed
     required_addons = (addons.UseAddon, addons.ProfileAddon)
-    known_results = (MetadataError, RequiredUseDefaults) + addons.UseAddon.known_results
+    known_results = (MetadataError, RequiredUseDefaults
+            ) + glep73_known_results + addons.UseAddon.known_results
 
     def __init__(self, options, iuse_handler, profiles):
         super(RequiredUSEMetadataReport, self).__init__(options)
@@ -166,6 +168,10 @@ class RequiredUSEMetadataReport(base.Template):
             reporter.add_report(MetadataError(
                 pkg, 'required_use', "exception- %s" % e))
             del e
+
+        # check GLEP 73 syntax first, so that we know if we can perform
+        # further tests
+        glep73_valid = glep73_validate_syntax(pkg.required_use, reporter, pkg)
 
         # check both stable/unstable profiles for stable KEYWORDS and only
         # unstable profiles for unstable KEYWORDS

--- a/src/pkgcheck/metadata_checks.py
+++ b/src/pkgcheck/metadata_checks.py
@@ -230,12 +230,10 @@ class RequiredUSEMetadataReport(base.Template):
             for node in failures.iterkeys():
                 reporter.add_report(RequiredUseDefaults(pkg, node))
 
-        # collapse errors that occur within multiple profiles
         for report_data in glep73_failures.itervalues():
-            all_profiles = []
             for report, keyword, profile in report_data:
-                all_profiles.append((keyword, profile))
-            reporter.add_report(report(pkg=pkg, profiles=all_profiles))
+                reporter.add_report(report(pkg=pkg,
+                    profile=(keyword, profile)))
 
 
 class UnusedLocalFlags(base.Warning):

--- a/src/pkgcheck/metadata_checks.py
+++ b/src/pkgcheck/metadata_checks.py
@@ -12,7 +12,7 @@ from snakeoil.strings import pluralism
 
 from . import base, addons
 from .glep73 import (glep73_validate_syntax, glep73_run_checks,
-                     glep73_known_results)
+                     glep73_known_results, glep73_get_all_flags)
 from .visibility import FakeConfigurable
 
 demandload('logging')
@@ -173,6 +173,8 @@ class RequiredUSEMetadataReport(base.Template):
         # check GLEP 73 syntax first, so that we know if we can perform
         # further tests
         glep73_valid = glep73_validate_syntax(pkg.required_use, reporter, pkg)
+        if glep73_valid:
+            glep73_all_flags = glep73_get_all_flags(pkg.required_use)
 
         # check both stable/unstable profiles for stable KEYWORDS and only
         # unstable profiles for unstable KEYWORDS
@@ -200,10 +202,11 @@ class RequiredUSEMetadataReport(base.Template):
                 if glep73_valid:
                     # PMS note: mask takes precedence over force
                     immutables = {}
-                    for x in src._forced_use:
-                        immutables[x] = True
-                    for x in src._masked_use:
-                        immutables[x] = False
+                    for x in glep73_all_flags:
+                        for x in src._forced_use:
+                            immutables[x] = True
+                        for x in src._masked_use:
+                            immutables[x] = False
 
                     cache_key = tuple(immutables.iteritems())
                     if cache_key in glep73_cache:

--- a/src/pkgcheck/test/test_glep73.py
+++ b/src/pkgcheck/test/test_glep73.py
@@ -1,0 +1,67 @@
+from pkgcore.test.misc import FakePkg
+
+from pkgcheck import glep73, metadata_checks, addons
+from pkgcheck.test import misc
+from pkgcheck.test.test_metadata_checks import iuse_options
+
+
+class TestGLEP73(iuse_options, misc.ReportTestCase):
+
+    check_kls = metadata_checks.RequiredUSEMetadataReport
+
+    def setUp(self):
+        super(TestGLEP73, self).setUp()
+        options = self.get_options(verbose=1,
+                                   use_desc=('a', 'b', 'c'))
+        profiles = {'x86': [misc.FakeProfile(name='default/linux/x86')]}
+        self.check = metadata_checks.RequiredUSEMetadataReport(
+            options, addons.UseAddon(options, profiles['x86']), profiles)
+        self.check.start()
+
+    def mk_pkg(self, eapi="5", iuse="", required_use="", keywords="x86"):
+        return FakePkg(
+            "dev-foo/bar-1",
+            eapi=eapi,
+            iuse=iuse.split(),
+            data={"REQUIRED_USE": required_use, "KEYWORDS": keywords})
+
+    def test_syntax(self):
+        # ||/??/^^ can only contain plain flags
+        r = self.assertReport(self.check, self.mk_pkg(iuse="+a b c", required_use="|| ( a ( b c ) )"))
+        self.assertIsInstance(r, glep73.GLEP73Syntax)
+        r = self.assertReport(self.check, self.mk_pkg(iuse="+a b c", required_use="|| ( a b? ( c ) )"))
+        self.assertIsInstance(r, glep73.GLEP73Syntax)
+        r = self.assertReport(self.check, self.mk_pkg(iuse="+a b c", required_use="|| ( a || ( b c ) )"))
+        self.assertIsInstance(r, glep73.GLEP73Syntax)
+        r = self.assertReport(self.check, self.mk_pkg(iuse="+a b c", required_use="|| ( a ?? ( b c ) )"))
+        self.assertIsInstance(r, glep73.GLEP73Syntax)
+        r = self.assertReport(self.check, self.mk_pkg(iuse="+a b c", required_use="|| ( a ^^ ( b c ) )"))
+        self.assertIsInstance(r, glep73.GLEP73Syntax)
+        r = self.assertReport(self.check, self.mk_pkg(iuse="+a b c", required_use="?? ( a ( b c ) )"))
+        self.assertIsInstance(r, glep73.GLEP73Syntax)
+        r = self.assertReport(self.check, self.mk_pkg(iuse="+a b c", required_use="?? ( a b? ( c ) )"))
+        self.assertIsInstance(r, glep73.GLEP73Syntax)
+        r = self.assertReport(self.check, self.mk_pkg(iuse="+a b c", required_use="?? ( a || ( b c ) )"))
+        self.assertIsInstance(r, glep73.GLEP73Syntax)
+        r = self.assertReport(self.check, self.mk_pkg(iuse="+a +b +c", required_use="?? ( a ?? ( b c ) )"))
+        self.assertIsInstance(r, glep73.GLEP73Syntax)
+        r = self.assertReport(self.check, self.mk_pkg(iuse="+a b c", required_use="?? ( a ^^ ( b c ) )"))
+        self.assertIsInstance(r, glep73.GLEP73Syntax)
+        r = self.assertReport(self.check, self.mk_pkg(iuse="+a b c", required_use="^^ ( a ( b c ) )"))
+        self.assertIsInstance(r, glep73.GLEP73Syntax)
+        r = self.assertReport(self.check, self.mk_pkg(iuse="+a b c", required_use="^^ ( a b? ( c ) )"))
+        self.assertIsInstance(r, glep73.GLEP73Syntax)
+        r = self.assertReport(self.check, self.mk_pkg(iuse="+a b c", required_use="^^ ( a || ( b c ) )"))
+        self.assertIsInstance(r, glep73.GLEP73Syntax)
+        r = self.assertReport(self.check, self.mk_pkg(iuse="+a +b +c", required_use="^^ ( a ?? ( b c ) )"))
+        self.assertIsInstance(r, glep73.GLEP73Syntax)
+        r = self.assertReport(self.check, self.mk_pkg(iuse="+a b c", required_use="^^ ( a ^^ ( b c ) )"))
+        self.assertIsInstance(r, glep73.GLEP73Syntax)
+
+    def test_syntax_allof(self):
+        # all-of groups in meaningless contexts
+        r = self.assertReport(self.check, self.mk_pkg(iuse="+a +b", required_use="( a b )"))
+        self.assertIsInstance(r, glep73.GLEP73Syntax)
+        r = self.assertReport(self.check, self.mk_pkg(iuse="a b c", required_use="a? ( ( b c ) )"))
+        self.assertIsInstance(r, glep73.GLEP73Syntax)
+    test_syntax_allof.todo = "meaningless all-of groups are collapsed by pkgcore"

--- a/src/pkgcheck/test/test_glep73.py
+++ b/src/pkgcheck/test/test_glep73.py
@@ -324,3 +324,33 @@ class TestGLEP73(iuse_options, misc.ReportTestCase):
             [([f('a'), f('b')], f('c')), ([f('a'), f('b')], f('d'))])
         self.assertEqual(glep73.strip_common_prefix(fr[0][0], fr[1][0]),
             ([f('b')], [f('b')]))
+
+    def test_test_condition(self):
+        f = glep73.GLEP73Flag
+        nf = lambda x: glep73.GLEP73Flag(x, negate=True)
+
+        self.assertTrue(glep73.test_condition(
+            [f('a')], {'a': True}, False))
+        self.assertTrue(glep73.test_condition(
+            [nf('a')], {'a': False}, False))
+        self.assertFalse(glep73.test_condition(
+            [nf('a')], {'a': True}, False))
+        self.assertFalse(glep73.test_condition(
+            [f('a')], {'a': False}, False))
+
+        # multiple conditions
+        self.assertTrue(glep73.test_condition(
+            [f('a'), f('b'), f('c')],
+            {'a': True, 'b': True, 'c': True}, False))
+        self.assertFalse(glep73.test_condition(
+            [f('a'), f('b'), f('c')],
+            {'a': False, 'b': True, 'c': True}, False))
+        self.assertFalse(glep73.test_condition(
+            [f('a'), f('b'), f('c')],
+            {'a': True, 'b': True, 'c': False}, False))
+
+        # fallback bit
+        self.assertTrue(glep73.test_condition([f('a')], {}, True))
+        self.assertFalse(glep73.test_condition([f('a')], {}, False))
+        self.assertTrue(glep73.test_condition([nf('a')], {}, True))
+        self.assertFalse(glep73.test_condition([nf('a')], {}, False))

--- a/src/pkgcheck/test/test_glep73.py
+++ b/src/pkgcheck/test/test_glep73.py
@@ -398,3 +398,15 @@ class TestGLEP73(iuse_options, misc.ReportTestCase):
         # invalid initial flags
         self.assertRaises(glep73.ConflictingInitialFlags, glep73.get_final_flags,
             [], [f('a'), nf('a')])
+
+        # common prefix problem
+        # a? ( !a b )
+        fa = f('a')
+        self.assertEqual(glep73.get_final_flags(
+            [([fa], nf('a')), ([fa], f('b'))], [f('a')]),
+            {'a': False, 'b': True})
+        # false positive test:
+        # a? ( !a ) a? ( b )
+        self.assertEqual(glep73.get_final_flags(
+            [([f('a')], nf('a')), ([f('a')], f('b'))], [f('a')]),
+            {'a': False})

--- a/src/pkgcheck/test/test_glep73.py
+++ b/src/pkgcheck/test/test_glep73.py
@@ -217,3 +217,26 @@ class TestGLEP73(iuse_options, misc.ReportTestCase):
             iuse="a b", required_use="a? ( !b )"))
         self.assertNoReport(self.check, self.mk_pkg(cpv="dev-foo/b-forced-a-masked-1",
             iuse="a b", required_use="a? ( !b )"))
+
+    def test_conditions_can_coexist(self):
+        f = glep73.GLEP73Flag
+        nf = lambda x: glep73.GLEP73Flag(x, negate=True)
+
+        self.assertTrue(glep73.conditions_can_coexist([], []))
+        self.assertTrue(glep73.conditions_can_coexist([f('a')], [f('a')]))
+        self.assertTrue(glep73.conditions_can_coexist(
+            [f('a'), f('b'), f('c')], [f('d'), f('e'), f('f')]))
+        self.assertTrue(glep73.conditions_can_coexist(
+            [f('a'), f('b'), f('c')], [f('c'), nf('d'), nf('e')]))
+        self.assertFalse(glep73.conditions_can_coexist(
+            [f('a'), f('b'), f('c')], [nf('c'), nf('d'), nf('e')]))
+        self.assertTrue(glep73.conditions_can_coexist(
+            [f('a'), f('b'), f('c')], [f('a'), f('b'), f('a'), f('b'), f('a')]))
+        self.assertTrue(glep73.conditions_can_coexist(
+            [f('a'), f('b'), f('c')], []))
+        self.assertFalse(glep73.conditions_can_coexist(
+            [f('a'), f('b'), f('c')], [nf('a')]))
+        self.assertFalse(glep73.conditions_can_coexist(
+            [f('a'), f('b'), f('c')], [f('a'), nf('a')]))
+        self.assertFalse(glep73.conditions_can_coexist(
+            [f('a'), f('b'), f('c')], [f('c'), f('b'), nf('a')]))

--- a/src/pkgcheck/test/test_glep73.py
+++ b/src/pkgcheck/test/test_glep73.py
@@ -263,8 +263,6 @@ class TestGLEP73(iuse_options, misc.ReportTestCase):
             required_use="!static? ( ^^ ( gcrypt kernel nettle openssl ) ) " +
                 "static? ( ^^ ( kernel nettle openssl ) )"))
 
-    test_conflicts_real_example.todo = "confused by partial back-alteration check"
-
     def test_conflict_disarmed_by_preceding_rules(self):
         self.assertNoReport(self.check, self.mk_pkg(
             iuse="a b c", required_use="a? ( !b c ) b? ( !c )"))
@@ -450,16 +448,10 @@ class TestGLEP73(iuse_options, misc.ReportTestCase):
             iuse="a b", required_use="a? ( !b ) b? ( a )"))
         self.assertIsInstance(r, glep73.GLEP73BackAlteration)
 
-    test_back_alteration_circular.todo = (
-            "Need to implement checking previous constraints")
-
     def test_back_alteration_duplicate_enforcement(self):
         self.assertNoReport(self.check, self.mk_pkg(
             iuse="jit shadowstack x86",
             required_use='!jit? ( !shadowstack ) x86? ( !jit !shadowstack )'))
-
-    test_back_alteration_duplicate_enforcement.todo = (
-            "Need to implement checking previous constraints")
 
     def test_condition_always_occurs(self):
         f = glep73.GLEP73Flag

--- a/src/pkgcheck/test/test_glep73.py
+++ b/src/pkgcheck/test/test_glep73.py
@@ -354,3 +354,47 @@ class TestGLEP73(iuse_options, misc.ReportTestCase):
         self.assertFalse(glep73.test_condition([f('a')], {}, False))
         self.assertTrue(glep73.test_condition([nf('a')], {}, True))
         self.assertFalse(glep73.test_condition([nf('a')], {}, False))
+
+    def test_get_final_flags(self):
+        f = glep73.GLEP73Flag
+        nf = lambda x: glep73.GLEP73Flag(x, negate=True)
+
+        # initial flags
+        self.assertEqual(glep73.get_final_flags([], [f('a')]),
+            {'a': True})
+        self.assertEqual(glep73.get_final_flags([], [nf('a')]),
+            {'a': False})
+
+        # plain constraints:
+        # a
+        self.assertEqual(glep73.get_final_flags(
+            [([], f('a'))], []),
+            {'a': True})
+        # a? ( b )
+        self.assertEqual(glep73.get_final_flags(
+            [([f('a')], f('b'))], []),
+            {})
+        self.assertEqual(glep73.get_final_flags(
+            [([f('a')], f('b'))], [nf('a')]),
+            {'a': False})
+        self.assertEqual(glep73.get_final_flags(
+            [([f('a')], f('b'))], [f('a')]),
+            {'a': True, 'b': True})
+        # a? ( !b )
+        self.assertEqual(glep73.get_final_flags(
+            [([f('a')], nf('b'))], [f('a')]),
+            {'a': True, 'b': False})
+        self.assertEqual(glep73.get_final_flags(
+            [([f('a')], nf('b'))], [f('b')]),
+            {'b': True})
+        self.assertEqual(glep73.get_final_flags(
+            [([f('a')], nf('b'))], [f('a'), f('b')]),
+            {'a': True, 'b': False})
+        # a? ( !a )
+        self.assertEqual(glep73.get_final_flags(
+            [([f('a')], nf('a'))], [f('a')]),
+            {'a': False})
+
+        # invalid initial flags
+        self.assertRaises(glep73.ConflictingInitialFlags, glep73.get_final_flags,
+            [], [f('a'), nf('a')])

--- a/src/pkgcheck/test/test_glep73.py
+++ b/src/pkgcheck/test/test_glep73.py
@@ -410,3 +410,22 @@ class TestGLEP73(iuse_options, misc.ReportTestCase):
         self.assertEqual(glep73.get_final_flags(
             [([f('a')], nf('a')), ([f('a')], f('b'))], [f('a')]),
             {'a': False})
+
+    def test_condition_can_occur(self):
+        f = glep73.GLEP73Flag
+        nf = lambda x: glep73.GLEP73Flag(x, negate=True)
+
+        # b? ( !a )
+        self.assertTrue(glep73.condition_can_occur(
+            [f('a')], [([f('b')], nf('a'))], []))
+        self.assertTrue(glep73.condition_can_occur(
+            [f('a')], [([f('b')], nf('a'))], [f('a')]))
+        self.assertFalse(glep73.condition_can_occur(
+            [f('a')], [([f('b')], nf('a'))], [f('b')]))
+        # common prefix: b? ( !b !a )
+        fb = f('b')
+        self.assertFalse(glep73.condition_can_occur(
+            [f('a')], [([fb], nf('b')), ([fb], nf('a'))], [f('b')]))
+        # no common prefix: b? ( !b ) b? ( !a )
+        self.assertTrue(glep73.condition_can_occur(
+            [f('a')], [([f('b')], nf('b')), ([f('b')], nf('a'))], [f('b')]))

--- a/src/pkgcheck/test/test_glep73.py
+++ b/src/pkgcheck/test/test_glep73.py
@@ -460,3 +460,31 @@ class TestGLEP73(iuse_options, misc.ReportTestCase):
 
     test_back_alteration_duplicate_enforcement.todo = (
             "Need to implement checking previous constraints")
+
+    def test_condition_always_occurs(self):
+        f = glep73.GLEP73Flag
+        nf = lambda x: glep73.GLEP73Flag(x, negate=True)
+
+        # a? ( b )
+        self.assertFalse(glep73.condition_always_occurs(
+            [f('b')], [([f('a')], f('b'))], []))
+        self.assertTrue(glep73.condition_always_occurs(
+            [f('b')], [([f('a')], f('b'))], [f('b')]))
+        self.assertTrue(glep73.condition_always_occurs(
+            [f('b')], [([f('a')], f('b'))], [f('a')]))
+        # a? ( b? ( c ) )
+        self.assertFalse(glep73.condition_always_occurs(
+            [f('c')], [([f('a'), f('b')], f('c'))], []))
+        self.assertFalse(glep73.condition_always_occurs(
+            [f('c')], [([f('a'), f('b')], f('c'))], [f('a')]))
+        self.assertTrue(glep73.condition_always_occurs(
+            [f('c')], [([f('a'), f('b')], f('c'))], [f('a'), f('b')]))
+        self.assertTrue(glep73.condition_always_occurs(
+            [f('c')], [([f('a'), f('b')], f('c'))], [f('a'), f('c')]))
+        # common prefix: a? ( !a b )
+        fa = f('a')
+        self.assertTrue(glep73.condition_always_occurs(
+            [f('b')], [([fa], nf('a')), ([fa], f('b'))], [f('a')]))
+        # no common prefix: a? ( !a ) a? ( b )
+        self.assertFalse(glep73.condition_always_occurs(
+            [f('b')], [([f('a')], nf('a')), ([f('a')], f('b'))], [f('a')]))

--- a/src/pkgcheck/test/test_glep73.py
+++ b/src/pkgcheck/test/test_glep73.py
@@ -480,3 +480,8 @@ class TestGLEP73(iuse_options, misc.ReportTestCase):
         # no common prefix: a? ( !a ) a? ( b )
         self.assertFalse(glep73.condition_always_occurs(
             [f('b')], [([f('a')], nf('a')), ([f('a')], f('b'))], [f('a')]))
+
+    def test_self_conflicting_rule(self):
+        r = self.assertReport(self.check, self.mk_pkg(
+            iuse="a b", required_use="a? ( !a? ( b ) ) !b"))
+        self.assertIsInstance(r, glep73.GLEP73SelfConflicting)

--- a/src/pkgcheck/test/test_glep73.py
+++ b/src/pkgcheck/test/test_glep73.py
@@ -271,9 +271,6 @@ class TestGLEP73(iuse_options, misc.ReportTestCase):
             iuse="+amd64 x86 binary debug",
             required_use='!amd64? ( !x86? ( !debug binary ) ) debug? ( !binary )'))
 
-    test_conflict_disarmed_by_preceding_rules.todo = (
-            "implement taking preceding constraints into consideration")
-
     def test_strip_common_prefix(self):
         f = glep73.GLEP73Flag
 

--- a/src/pkgcheck/test/test_metadata_checks.py
+++ b/src/pkgcheck/test/test_metadata_checks.py
@@ -58,7 +58,7 @@ class iuse_options(TempDirMixin):
         fileutils.write_file(
             pjoin(base, "use.desc"), "w",
             "\n".join("%s - %s" % (x, x)
-                      for x in kwds.pop("use_desc", ("foo", "bar"))))
+                      for x in kwds.pop("use_desc", ("foo", "bar", "baz"))))
 
         fileutils.write_file(pjoin(base, 'repo_name'), 'w', 'monkeys')
         os.mkdir(pjoin(repo_base, 'metadata'))


### PR DESCRIPTION
Here I'll slowly implement the necessary bits for the new GLEP.

Plan:
- [x] restricted syntax verification,
  - [ ] detect meaningless (top-level, inside USE-conditional groups) all-of groups — they are currently collapsed by pkgcore [depends on pkgcore/pkgcore#235];
- [x] flat constraint transform,
  - [x] handling of immutability in transform,
  - [x] caching of results per unique sets of immutables,
- [x] immutability checks,
- [x] conflict checks,
  - [x] full false positive protection,
  - [x] reports for self-conflicting entries,
- [x] back-alteration checks,
  - [x] full false positive protection.

Other TODOs:
- [x] get final GLEP number,
- [ ] it seems that different issues are combined incorrectly, i.e. gentoo/gentoo@db974abb15e2355e288a020eaf16046c78542ed5 [[CI](https://qa-reports.gentoo.org/output/gentoo-ci/11c74473a/output.html#dev-python/ipython)] involves immutability test->qt4 in ppc & test->octave in arm (see: [[CI2](https://qa-reports.gentoo.org/output/gentoo-ci/86157b00c/output.html#dev-python/ipython)]) while the reports combines both into test->qt4.

This time with tests.