### PR TITLE
checks.metadata_checks: add preserve-libs to known restricts

### DIFF
--- a/src/pkgcheck/checks/metadata_checks.py
+++ b/src/pkgcheck/checks/metadata_checks.py
@@ -848,7 +848,7 @@ class RestrictsReport(base.Template):
     feed_type = base.versioned_feed
     known_restricts = frozenset((
         "binchecks", "bindist", "fetch", "installsources", "mirror",
-        "primaryuri", "splitdebug", "strip", "test", "userpriv",
+        "preserve-libs", "primaryuri", "splitdebug", "strip", "test", "userpriv",
     ))
 
     known_results = (BadRestricts,) + addons.UseAddon.known_results


### PR DESCRIPTION
Saw this in gentoo's CI output as 

```
BadRestricts | unknown restricts: preserve-libs
```

it's a valid restrict.

https://github.com/gentoo/portage/blob/7f2c4b0d402be190a9575346a76e3ee9361179ac/repoman/cnf/repository/qa_data.yaml#L151-L162