### PR TITLE
checks/repo_metadata.py: flag as UnusedProfileDirs deprecated profiles

### DIFF
--- a/src/pkgcheck/checks/repo_metadata.py
+++ b/src/pkgcheck/checks/repo_metadata.py
@@ -760,11 +760,9 @@ class RepoProfilesReport(base.Template):
         root_profile_dirs = {'embedded'}
         available_profile_dirs = set()
         for root, _dirs, _files in os.walk(self.profiles_dir):
-            # skip deprecated profiles
-            if not os.path.exists(pjoin(root, 'deprecated')):
-                d = root[len(self.profiles_dir):].lstrip('/')
-                if d:
-                    available_profile_dirs.add(d)
+            d = root[len(self.profiles_dir):].lstrip('/')
+            if d:
+                available_profile_dirs.add(d)
         available_profile_dirs -= self.non_profile_dirs | root_profile_dirs
 
         def parents(path):


### PR DESCRIPTION
Deprecated profiles still should be listed in 'profiles.desc' to
have a chance of repoman to be checked as a real profile for sanity.
'profiles.desc' is also a good place to add detailed deprecation comment.

Let's complain about unreferenced 'deprecated' profiles.

Closes: https://github.com/pkgcore/pkgcheck/issues/77