### PR TITLE
ManifestReport: make it repo-scope

### DIFF
--- a/src/pkgcheck/checks/repo_metadata.py
+++ b/src/pkgcheck/checks/repo_metadata.py
@@ -1168,6 +1168,7 @@ class ManifestReport(base.Template):
     """
 
     required_addons = (addons.UseAddon,)
+    scope = base.repository_scope
     feed_type = base.package_feed
     known_results = (
         MissingChksum, MissingManifest, UnknownManifest, UnnecessaryManifest,


### PR DESCRIPTION
Make ManifestReport repo-scope so that it will always catch conflicting
checksums correctly.

------
This should be the last thing to remove patching from pkgcheck for CI.

Alternatively (or later on), we could split the conflict check from ManifestReport, and change only the latter.