### PR TITLE
repo_metadata: Split Manifest conflict check out of ManifestReport

### DIFF
--- a/src/pkgcheck/checks/repo_metadata.py
+++ b/src/pkgcheck/checks/repo_metadata.py
@@ -1066,7 +1066,7 @@ class ConflictingChksums(base.Error):
     def short_desc(self):
         return (
             f"conflicts with ({', '.join(self.others)}) "
-            "for file {self.filename!r} chksum {self.chksums}")
+            f"for file {self.filename!r} chksum {self.chksums}")
 
 
 class MissingChksum(base.Warning):

--- a/src/pkgcheck/plugins/core_checks.py
+++ b/src/pkgcheck/plugins/core_checks.py
@@ -37,6 +37,7 @@ pkgcore_plugins = {
         pkgdir_checks.PkgDirReport,
         repo_metadata.GlobalUSECheck,
         repo_metadata.LicenseGroupsCheck,
+        repo_metadata.ManifestConflictCheck,
         repo_metadata.ManifestReport,
         repo_metadata.PackageUpdatesCheck,
         repo_metadata.ProfilesCheck,


### PR DESCRIPTION
Split the Manifest checks into package-scope ManifestReport
and repo-scope ManifestConflictCheck.  This ensures that the former
is normally run when pkgcheck is called with a single package, while
the latter is run on whole repository where it can efficiently detect
checksum conflicts.  This is useful for Gentoo CI since it runs pkgcheck
per-category, and needs to run global checks separately.

Also includes a fix for silly typo in format string.