### PR TITLE
deprecated: Mark user.eclass deprecated, in favor of GLEP 81

### DIFF
--- a/src/pkgcheck/checks/deprecated.py
+++ b/src/pkgcheck/checks/deprecated.py
@@ -107,6 +107,7 @@ class DeprecatedEclassReport(base.Template):
         'ruby-gnome2': 'ruby-ng-gnome2',
         'tla': None,
         'ltprune': None,
+        'user': 'GLEP 81',
         'vim': None,
         'webapp-apache': None,
         'x-modular': 'xorg-2',


### PR DESCRIPTION
Signed-off-by: Michał Górny <mgorny@gentoo.org>