### PR TITLE
ObsoleteUriCheck: fix replacement GitLab URI, improve re readability

### DIFF
--- a/src/pkgcheck/checks/codingstyle.py
+++ b/src/pkgcheck/checks/codingstyle.py
@@ -334,10 +334,13 @@ class ObsoleteUriCheck(base.Template):
     known_results = (ObsoleteUri,)
 
     REGEXPS = (
-        (r'.*\b(?P<uri>(https?://github\.com/.*?/.*?/)(?:tar|zip)ball(\S*))',
-         r'\2archive\3.tar.gz'),
-        (r'.*\b(?P<uri>(https?://gitlab\.com/.*?/.*?/)repository/archive\.(tar|tar\.gz|tar\.bz2|zip)\?ref=(\S*))',
-         r'\2-/archive/\4.\3'),
+        (r'.*\b(?P<uri>(?P<prefix>https?://github\.com/.*?/.*?/)'
+         r'(?:tar|zip)ball(?P<ref>\S*))',
+         r'\g<prefix>archive\g<ref>.tar.gz'),
+        (r'.*\b(?P<uri>(?P<prefix>https?://gitlab\.com/.*?/(?P<pkg>.*?)/)'
+         r'repository/archive\.(?P<format>tar|tar\.gz|tar\.bz2|zip)'
+         r'\?ref=(?P<ref>\S*))',
+         r'\g<prefix>-/archive/\g<ref>/\g<pkg>-\g<ref>.\g<format>'),
     )
 
     def __init__(self, options):

--- a/tests/checks/test_codingstyle.py
+++ b/tests/checks/test_codingstyle.py
@@ -170,9 +170,9 @@ class TestObsoleteUri(misc.ReportTestCase):
                 'https://github.com/foo/bar/archive/${PV}.tar.gz')
 
     def test_gitlab_archive_uri(self):
-        uri = 'https://gitlab.com/foo/bar/-/archive/${PV}.tar.gz'
+        uri = 'https://gitlab.com/foo/bar/-/archive/${PV}/${P}.tar.gz'
         fake_src = [
-            f'SRC_URI="{uri} -> ${{P}}.tar.gz"\n'
+            f'SRC_URI="{uri}"\n'
         ]
         self.assertNoReport(self.check_kls(options=None), [self.fake_pkg, fake_src])
 
@@ -187,7 +187,7 @@ class TestObsoleteUri(misc.ReportTestCase):
         assert r.line == 1
         assert r.uri == uri
         assert (r.replacement ==
-                'https://gitlab.com/foo/bar/-/archive/${PV}.tar.gz')
+                'https://gitlab.com/foo/bar/-/archive/${PV}/bar-${PV}.tar.gz')
 
     def test_gitlab_tar_bz2_uri(self):
         uri = 'https://gitlab.com/foo/bar/repository/archive.tar.bz2?ref=${PV}'
@@ -200,7 +200,7 @@ class TestObsoleteUri(misc.ReportTestCase):
         assert r.line == 1
         assert r.uri == uri
         assert (r.replacement ==
-                'https://gitlab.com/foo/bar/-/archive/${PV}.tar.bz2')
+                'https://gitlab.com/foo/bar/-/archive/${PV}/bar-${PV}.tar.bz2')
 
     def test_gitlab_zip_uri(self):
         uri = 'https://gitlab.com/foo/bar/repository/archive.zip?ref=${PV}'
@@ -213,4 +213,4 @@ class TestObsoleteUri(misc.ReportTestCase):
         assert r.line == 1
         assert r.uri == uri
         assert (r.replacement ==
-                'https://gitlab.com/foo/bar/-/archive/${PV}.zip')
+                'https://gitlab.com/foo/bar/-/archive/${PV}/bar-${PV}.zip')


### PR DESCRIPTION
Fix GitLab replacement URI to use the full form that enables correct
directory naming.  While GitLab accepts pretty much anything, only
the one true form guarantees reasonable contents.

While at it, use named groups to make the regexps more readable.