### PR TITLE
BadRestrictsCheck: permit preserve-libs

### DIFF
--- a/src/pkgcheck/checks/metadata_checks.py
+++ b/src/pkgcheck/checks/metadata_checks.py
@@ -1022,7 +1022,8 @@ class RestrictsCheck(base.Template):
     feed_type = base.versioned_feed
     known_restricts = frozenset((
         "binchecks", "bindist", "fetch", "installsources", "mirror",
-        "primaryuri", "splitdebug", "strip", "test", "userpriv",
+        "preserve-libs", "primaryuri", "splitdebug", "strip", "test",
+        "userpriv",
     ))
 
     known_results = (BadRestricts, addons.UnstatedIUSE)


### PR DESCRIPTION
RESTRICT=preserve-libs has been added to Portage recently.  Since
the use case seems valid, and PMS permits additional values not listed
in the spec, stop complaining about it.

// NB: I'm not including network-sandbox since it's not allowed in ::gentoo.