### PR TITLE
python: Exempt virtual/pypy* from eclass check

### DIFF
--- a/src/pkgcheck/checks/python.py
+++ b/src/pkgcheck/checks/python.py
@@ -21,6 +21,8 @@ INTERPRETERS = frozenset([
     'virtual/pypy3',
 ])
 
+CHECK_EXCLUDE = frozenset(['virtual/pypy', 'virtual/pypy3'])
+
 IUSE_PREFIX = 'python_targets_'
 IUSE_PREFIX_S = 'python_single_target_'
 
@@ -237,6 +239,11 @@ class PythonCheck(base.Template):
             return
 
         if eclass is None:
+            # virtual/pypy* need to be exempted as they serve as slot-matchers
+            # for other packages
+            if pkg.key in CHECK_EXCLUDE:
+                return
+
             # check whether we should be using one
             highest_found = None
             for attr in ("bdepend", "depend", "rdepend", "pdepend"):

--- a/tests/module/checks/test_python.py
+++ b/tests/module/checks/test_python.py
@@ -9,9 +9,9 @@ class TestPythonReport(misc.ReportTestCase):
     check = python.PythonCheck(None)
     check_kls = python.PythonCheck
 
-    def mk_pkg(self, **kwargs):
+    def mk_pkg(self, cpv="app-foo/bar-1", **kwargs):
         kwargs.setdefault('EAPI', '7')
-        return misc.FakePkg("app-foo/bar-1", data=kwargs)
+        return misc.FakePkg(cpv, data=kwargs)
 
     def test_multiple_eclasses(self):
         r = self.assertReport(
@@ -103,6 +103,12 @@ class TestPythonReport(misc.ReportTestCase):
         assert isinstance(
             self.assertReport(self.check, self.mk_pkg(RDEPEND='dev-python/pypy')),
             python.MissingPythonEclass)
+
+        # special exception: virtual/pypy
+        self.assertNoReport(self.check, self.mk_pkg(cpv='virtual/pypy-4.1',
+            RDEPEND='|| ( dev-python/pypy:0/41 dev-python/pypy-bin:0/41 )'))
+        self.assertNoReport(self.check, self.mk_pkg(cpv='virtual/pypy3-4.1',
+            RDEPEND='|| ( dev-python/pypy3:0/41 dev-python/pypy3-bin:0/41 )'))
 
     def test_missing_eclass_pdepend(self):
         self.assertNoReport(


### PR DESCRIPTION
The virtual/pypy* is used as an implementation package, and its special
contents trigger false positive.  While I could technically try to hack
it over, it's probably cleaner to exempt it straight in the check.