### PR TITLE
Split invalid/old copyright checks outta git checks, and improve

### DIFF
--- a/src/pkgcheck/checks/codingstyle.py
+++ b/src/pkgcheck/checks/codingstyle.py
@@ -487,11 +487,34 @@ class OldGentooCopyright(base.Warning):
         return f'old copyright, update to "Gentoo Authors": {self.line!r}'
 
 
+class NonGentooAuthorsCopyright(base.Warning):
+    """Ebuild with copyright stating owner other than "Gentoo Authors".
+
+    The ebuild specifies explicit copyright owner, while the Gentoo repository
+    policy specifies that all ebuilds must use "Gentoo Authors".  If the owner
+    is not listed in metadata/AUTHORS, addition can be requested
+    via bugs.gentoo.org.
+    """
+
+    __slots__ = ('category', 'package', 'version', 'line')
+    threshold = base.versioned_feed
+
+    def __init__(self, pkg, line):
+        super().__init__()
+        self._store_cpv(pkg)
+        self.line = line
+
+    @property
+    def short_desc(self):
+        return f'copyright line must state "Gentoo Authors": {self.line!r}'
+
+
 class CopyrightCheck(base.Template):
     """Scan ebuild for incorrect copyright header."""
 
     feed_type = base.ebuild_feed
-    known_results = (InvalidCopyright, OldGentooCopyright)
+    known_results = (InvalidCopyright, OldGentooCopyright,
+                     NonGentooAuthorsCopyright)
 
     def feed(self, entry):
         pkg, lines = entry
@@ -505,3 +528,7 @@ class CopyrightCheck(base.Template):
             elif int(copyright.group('end')) >= 2019:
                 if copyright.group('holder') == 'Gentoo Foundation':
                     yield OldGentooCopyright(pkg, line.strip('\n'))
+                # Gentoo policy requires 'Gentoo Authors'
+                elif (pkg.repo.repo_id == 'gentoo' and
+                      copyright.group('holder') != 'Gentoo Authors'):
+                    yield NonGentooAuthorsCopyright(pkg, line.strip('\n'))

--- a/src/pkgcheck/checks/codingstyle.py
+++ b/src/pkgcheck/checks/codingstyle.py
@@ -2,12 +2,16 @@
 
 from collections import defaultdict
 
-from snakeoil.demandload import demandload
+from snakeoil.demandload import demandload, demand_compile_regexp
 from snakeoil.strings import pluralism as _pl
 
 from .. import base
 
 demandload("re")
+
+demand_compile_regexp(
+    'ebuild_copyright_regex',
+    r'^# Copyright (?P<begin>\d{4}-)?(?P<end>\d{4}) (?P<holder>.+)$')
 
 
 class HttpsAvailable(base.Warning):
@@ -431,3 +435,73 @@ class ObsoleteUriCheck(base.Template):
                 if matches is not None:
                     uri = matches.group('uri')
                     yield ObsoleteUri(pkg, lineno, uri, regexp.sub(repl, uri))
+
+
+class InvalidCopyright(base.Warning):
+    """Ebuild with invalid copyright.
+
+    The ebuild does not start with a valid copyright line.  Each ebuild must
+    start with a copyright line of the form:
+
+        # Copyright YEARS MAIN-CONTRIBUTOR [OTHER-CONTRIBUTOR]... [and others]
+
+    Ebuilds in the Gentoo repository must use:
+
+        # Copyright YEARS Gentoo Authors
+    """
+
+    __slots__ = ('category', 'package', 'version', 'line')
+    threshold = base.versioned_feed
+
+    def __init__(self, pkg, line):
+        super().__init__()
+        self._store_cpv(pkg)
+        self.line = line
+
+    @property
+    def short_desc(self):
+        return f'invalid copyright: {self.line!r}'
+
+
+class OldGentooCopyright(base.Warning):
+    """Ebuild with old Gentoo Foundation copyright.
+
+    The ebuild still assigns copyright to the Gentoo Foundation even though
+    it has been committed after the new Copyright Policy was approved
+    (2018-10-21).
+
+    The ebuilds in Gentoo repository must use 'Gentoo Authors' instead.  Ebuilds
+    in other repositories may specify an explicit copyright holder instead.
+    """
+
+    __slots__ = ('category', 'package', 'version', 'line')
+    threshold = base.versioned_feed
+
+    def __init__(self, pkg, line):
+        super().__init__()
+        self._store_cpv(pkg)
+        self.line = line
+
+    @property
+    def short_desc(self):
+        return f'old copyright, update to "Gentoo Authors": {self.line!r}'
+
+
+class CopyrightCheck(base.Template):
+    """Scan ebuild for incorrect copyright header."""
+
+    feed_type = base.ebuild_feed
+    known_results = (InvalidCopyright, OldGentooCopyright)
+
+    def feed(self, entry):
+        pkg, lines = entry
+        if lines:
+            line = lines[0].strip()
+            copyright = ebuild_copyright_regex.match(line)
+            if copyright is None:
+                yield InvalidCopyright(pkg, line.strip('\n'))
+            # Copyright policy is active since 2018-10-21, so it applies
+            # to all ebuilds committed in 2019 and later
+            elif int(copyright.group('end')) >= 2019:
+                if copyright.group('holder') == 'Gentoo Foundation':
+                    yield OldGentooCopyright(pkg, line.strip('\n'))

--- a/src/pkgcheck/checks/git.py
+++ b/src/pkgcheck/checks/git.py
@@ -8,25 +8,6 @@ from .. import addons, base
 demand_compile_regexp(
     'ebuild_copyright_regex',
     r'^# Copyright (\d\d\d\d(-\d\d\d\d)?) .+')
-demand_compile_regexp(
-    'old_gentoo_copyright_regex',
-    r'^# Copyright (\d\d\d\d(-\d\d\d\d)?) Gentoo Foundation')
-
-
-class InvalidCopyright(base.Warning):
-    """Changed ebuild with invalid copyright."""
-
-    __slots__ = ('category', 'package', 'version', 'line')
-    threshold = base.versioned_feed
-
-    def __init__(self, pkg, line):
-        super().__init__()
-        self._store_cpv(pkg)
-        self.line = line
-
-    @property
-    def short_desc(self):
-        return f'invalid copyright: {self.line!r}'
 
 
 class OutdatedCopyright(base.Warning):
@@ -44,26 +25,6 @@ class OutdatedCopyright(base.Warning):
     @property
     def short_desc(self):
         return f'outdated copyright year {self.year!r}: {self.line!r}'
-
-
-class OldGentooCopyright(base.Warning):
-    """Changed ebuild with old Gentoo copyright.
-
-    Previously ebuilds assigned copyright to the Gentoo Foundation by default.
-    Now that's been changed to Gentoo Authors in GLEP 76.
-    """
-
-    __slots__ = ('category', 'package', 'version', 'line')
-    threshold = base.versioned_feed
-
-    def __init__(self, pkg, line):
-        super().__init__()
-        self._store_cpv(pkg)
-        self.line = line
-
-    @property
-    def short_desc(self):
-        return f'old copyright, update to "Gentoo Authors": {self.line!r}'
 
 
 class DirectStableKeywords(base.Error):
@@ -106,7 +67,7 @@ class GitCommitsCheck(base.DefaultRepoCheck):
     required_addons = (addons.GitAddon,)
     known_results = (
         DirectStableKeywords, DirectNoMaintainer,
-        InvalidCopyright, OutdatedCopyright, OldGentooCopyright,
+        OutdatedCopyright,
     )
 
     def __init__(self, options, git_addon):
@@ -133,10 +94,6 @@ class GitCommitsCheck(base.DefaultRepoCheck):
                 year = copyright.group(1).split('-')[-1]
                 if int(year) < self.today.year:
                     yield OutdatedCopyright(pkg, year, line.strip('\n'))
-                if old_gentoo_copyright_regex.match(line):
-                    yield OldGentooCopyright(pkg, line.strip('\n'))
-            else:
-                yield InvalidCopyright(pkg, line.strip('\n'))
 
             # checks for newly added ebuilds
             if git_pkg.status == 'A':

--- a/src/pkgcheck/plugins/core_checks.py
+++ b/src/pkgcheck/plugins/core_checks.py
@@ -15,6 +15,7 @@ pkgcore_plugins = {
         cleanup.RedundantVersionCheck,
         codingstyle.AbsoluteSymlinkCheck,
         codingstyle.BadInsIntoCheck,
+        codingstyle.CopyrightCheck,
         codingstyle.HttpsAvailableCheck,
         codingstyle.ObsoleteUriCheck,
         codingstyle.PathVariablesCheck,


### PR DESCRIPTION
Split checks for invalid copyright lines and 'Gentoo Foundation'
copyright outside the git checks since they can really work without git
and are quite useful.

Improve the regex used to catch copyrights to grab dates and copyright
holder.  Use the latter to detect 'Gentoo Foundation' rather than
a second regex match.  Furthermore, limit catching GF to ebuilds
committed in 2019 and newer, according to the copyright date.
If ebuilds have wrong copyright date, OutdatedCopyright should catch
that.

Also improve documentation to clearly indicate how copyright lines
should look like, and what holder to use for various repos.

Fixes #116