### PR TITLE
git: Read .git/info/exclude as well as .gitignore

### DIFF
--- a/src/pkgcheck/git.py
+++ b/src/pkgcheck/git.py
@@ -337,15 +337,18 @@ class GitAddon(base.Addon, base.Cache):
     @jit_attr
     def gitignore(self):
         """Load a repo's .gitignore file for path matching usage."""
-        path = pjoin(self.options.target_repo.location, '.gitignore')
+        paths = (pjoin(self.options.target_repo.location, p) for p in 
+                ('.gitignore', '.git/info/exclude'))
+
         patterns = []
-        try:
-            with open(path) as f:
-                patterns = f.readlines()
-        except FileNotFoundError:
-            pass
-        except IOError as e:
-            logger.warning(f'failed reading {path!r}: {e}')
+        for path in paths:
+            try:
+                with open(path) as f:
+                    patterns += f.readlines()
+            except FileNotFoundError:
+                pass
+            except IOError as e:
+                logger.warning(f'failed reading {path!r}: {e}')
         return PathSpec.from_lines('gitwildmatch', patterns)
 
     def gitignored(self, path):

--- a/tests/module/checks/test_repo.py
+++ b/tests/module/checks/test_repo.py
@@ -105,6 +105,13 @@ class TestRepoDirCheck(misc.Tmpdir, misc.ReportTestCase):
             f.write('/distfiles/')
         self.assertNoReport(self.mk_check(), [])
 
+        # also results are suppressed if a matching .git/info/exclude entry exists
+        os.unlink(pjoin(self.repo.location, '.gitignore'))
+        os.makedirs(pjoin(self.repo.location, '.git/info'), exist_ok=True)
+        with open(pjoin(self.repo.location, '.git/info/exclude'), 'w') as f:
+            f.write('/distfiles/')
+        self.assertNoReport(self.mk_check(), [])
+
     def test_non_utf8_encodings(self):
         # non-english languages courtesy of google translate mangling
         langs = (


### PR DESCRIPTION
Git will read "ignore" entries from both `.gitignore` and `.git/info/exclude`.
We should do the same thing so we have the same behaviour.