### PR TITLE
Include PGIDs in reports

### DIFF
--- a/src/pkgcheck/checks/acct.py
+++ b/src/pkgcheck/checks/acct.py
@@ -27,6 +27,8 @@ class MissingAccountIdentifier(results.VersionResult, results.Warning):
 class ConflictingAccountIdentifiers(results.Error):
     """Same UID/GID is used by multiple packages."""
 
+    pgid = 'PG0901'
+
     def __init__(self, kind, identifier, pkgs):
         super().__init__()
         self.kind = kind
@@ -42,6 +44,8 @@ class ConflictingAccountIdentifiers(results.Error):
 
 class OutsideRangeAccountIdentifier(results.VersionResult, results.Error):
     """UID/GID outside allowed allocation range."""
+
+    pgid = 'PG0901'
 
     def __init__(self, kind, identifier, **kwargs):
         super().__init__(**kwargs)

--- a/src/pkgcheck/checks/codingstyle.py
+++ b/src/pkgcheck/checks/codingstyle.py
@@ -265,6 +265,8 @@ class PathVariablesCheck(Check):
 class AbsoluteSymlink(results.LineResult, results.Warning):
     """Ebuild uses dosym with absolute paths instead of relative."""
 
+    pgid = 'PG0206'
+
     def __init__(self, cmd, **kwargs):
         super().__init__(**kwargs)
         self.cmd = cmd
@@ -421,6 +423,8 @@ class HomepageInSrcUri(results.VersionResult, results.Warning):
     not accidentally affect SRC_URI.
     """
 
+    pgid = 'PG0104'
+
     @property
     def desc(self):
         return '${HOMEPAGE} in SRC_URI'
@@ -450,6 +454,8 @@ class VariableInHomepage(results.VersionResult, results.Warning):
 
     .. [#] https://devmanual.gentoo.org/ebuild-writing/variables/#ebuild-defined-variables
     """
+
+    pgid = 'PG0103'
 
     def __init__(self, variables, **kwargs):
         super().__init__(**kwargs)

--- a/src/pkgcheck/checks/eclass.py
+++ b/src/pkgcheck/checks/eclass.py
@@ -9,6 +9,8 @@ from . import Check
 class DeprecatedEclass(results.VersionResult, results.Warning):
     """Package uses an eclass that is deprecated/abandoned."""
 
+    pgid = 'PG1003'
+
     def __init__(self, eclasses, **kwargs):
         super().__init__(**kwargs)
         self.eclasses = tuple(eclasses)

--- a/src/pkgcheck/checks/git.py
+++ b/src/pkgcheck/checks/git.py
@@ -158,6 +158,8 @@ class DirectNoMaintainer(results.PackageResult, results.Error):
 class RdependChange(results.PackageResult, results.Warning):
     """Package RDEPEND was modified without adding a new ebuild revision."""
 
+    pgid = 'PG0003'
+
     @property
     def desc(self):
         return 'RDEPEND modified without revbump'

--- a/src/pkgcheck/checks/metadata.py
+++ b/src/pkgcheck/checks/metadata.py
@@ -436,6 +436,8 @@ class UnderscoreInUseFlag(results.PackageResult, results.Warning):
     .. [#] https://projects.gentoo.org/pms/7/pms.html#x1-200003.1.4
     """
 
+    pgid = 'PG0803'
+
     def __init__(self, flag, **kwargs):
         super().__init__(**kwargs)
         self.flag = flag
@@ -510,6 +512,8 @@ class MissingSlotDep(results.VersionResult, results.Warning):
     .. [#] https://devmanual.gentoo.org/general-concepts/dependencies/#slot-dependencies
     """
 
+    pgid = 'PG0011'
+
     def __init__(self, dep, dep_slots, **kwargs):
         super().__init__(**kwargs)
         self.dep = dep
@@ -560,6 +564,8 @@ class MissingPackageRevision(results.VersionResult, results.Warning):
     allowed, ``-r0`` should be appended in order to make the intent explicit.
     """
 
+    pgid = 'PG0002'
+
     def __init__(self, dep, atom, **kwargs):
         super().__init__(**kwargs)
         self.dep = dep.upper()
@@ -572,6 +578,8 @@ class MissingPackageRevision(results.VersionResult, results.Warning):
 
 class MissingUseDepDefault(results.VersionResult, results.Warning):
     """Package dependencies with USE dependencies missing defaults."""
+
+    pgid = 'PG0021'
 
     def __init__(self, attr, atom, flag, pkgs, **kwargs):
         super().__init__(**kwargs)
@@ -1191,6 +1199,8 @@ class BadHomepage(results.VersionResult, results.Warning):
     .. [#] https://devmanual.gentoo.org/ebuild-writing/variables/#ebuild-defined-variables
     """
 
+    pgid = 'PG0702'
+
     def __init__(self, msg, **kwargs):
         super().__init__(**kwargs)
         self.msg = msg
@@ -1325,6 +1335,8 @@ class MissingTestRestrict(results.VersionResult, results.Warning):
     be skipped when the flag is disabled and therefore test dependencies may
     not be installed.
     """
+
+    pgid = 'PG0703'
 
     @property
     def desc(self):

--- a/src/pkgcheck/checks/metadata.py
+++ b/src/pkgcheck/checks/metadata.py
@@ -217,7 +217,7 @@ class DeprecatedEapi(_EapiResult, results.Warning):
     """Package's EAPI is deprecated according to repo metadata."""
 
     _type = 'deprecated'
-    pgid = '1001'
+    pgid = 'PG1001'
 
 
 class BannedEapi(_EapiResult, results.Error):

--- a/src/pkgcheck/checks/metadata.py
+++ b/src/pkgcheck/checks/metadata.py
@@ -217,6 +217,7 @@ class DeprecatedEapi(_EapiResult, results.Warning):
     """Package's EAPI is deprecated according to repo metadata."""
 
     _type = 'deprecated'
+    pgid = '1001'
 
 
 class BannedEapi(_EapiResult, results.Error):

--- a/src/pkgcheck/checks/python.py
+++ b/src/pkgcheck/checks/python.py
@@ -37,6 +37,8 @@ class MissingPythonEclass(results.VersionResult, results.Warning):
     .. [#] https://wiki.gentoo.org/wiki/Project:Python/Eclasses
     """
 
+    pgid = 'PG0501'
+
     def __init__(self, eclass, dep_type, dep, **kwargs):
         super().__init__(**kwargs)
         self.eclass = eclass
@@ -56,6 +58,8 @@ class PythonMissingRequiredUse(results.VersionResult, results.Warning):
     conditionally, it can be wrapped in appropriate USE conditionals.
     """
 
+    pgid = 'PG0501'
+
     @property
     def desc(self):
         return 'missing REQUIRED_USE="${PYTHON_REQUIRED_USE}"'
@@ -71,6 +75,8 @@ class PythonMissingDeps(results.VersionResult, results.Warning):
     If Python is used conditionally, the dependency can be wrapped
     in appropriate USE conditionals.
     """
+
+    pgid = 'PG0501'
 
     def __init__(self, dep_type, **kwargs):
         super().__init__(**kwargs)
@@ -90,6 +96,8 @@ class PythonRuntimeDepInAnyR1(results.VersionResult, results.Warning):
     python-r1 or python-single-r1 eclass, otherwise the runtime dependency
     should be removed.
     """
+
+    pgid = 'PG0501'
 
     def __init__(self, dep_type, dep, **kwargs):
         super().__init__(**kwargs)

--- a/src/pkgcheck/results.py
+++ b/src/pkgcheck/results.py
@@ -26,6 +26,8 @@ class Result(metaclass=_ResultAttrs):
     level = None
     color = None
     _name = None
+    # Policy Guide identifier ('PGnnnn')
+    pgid = None
 
     @property
     def name(self):

--- a/src/pkgcheck/scripts/pkgcheck.py
+++ b/src/pkgcheck/scripts/pkgcheck.py
@@ -853,7 +853,9 @@ def display_keywords(out, options):
                 out.first_prefix.append('  ')
                 out.later_prefix.append('  ')
                 for keyword in keywords:
-                    out.write(out.fg(keyword.color), keyword.__name__, out.reset, ':')
+                    out.write(out.fg(keyword.color), keyword.__name__, out.reset,
+                              f' [{keyword.pgid}]' if keyword.pgid is not None else '',
+                              ':')
                     dump_docstring(out, keyword, prefix='  ')
             finally:
                 out.first_prefix.pop()

--- a/tests/data/repos/standalone/DependencyCheck/MissingPackageRevision/expected
+++ b/tests/data/repos/standalone/DependencyCheck/MissingPackageRevision/expected
@@ -1,2 +1,2 @@
 DependencyCheck/MissingPackageRevision
-  MissingPackageRevision: version 0: "=" operator used without package revision: RDEPEND="=stub/stub1-0"
+  MissingPackageRevision: version 0: [PG0002] "=" operator used without package revision: RDEPEND="=stub/stub1-0"

--- a/tests/data/repos/standalone/DependencyCheck/MissingUseDepDefault/expected
+++ b/tests/data/repos/standalone/DependencyCheck/MissingUseDepDefault/expected
@@ -1,5 +1,5 @@
 DependencyCheck/MissingUseDepDefault
-  MissingUseDepDefault: version 0: BDEPEND="stub/stub3[foo?]": USE flag 'foo' missing from package: [ stub/stub3-0 ]
-  MissingUseDepDefault: version 0: DEPEND="stub/stub1[foo]": USE flag 'foo' missing from package: [ stub/stub1-0 ]
-  MissingUseDepDefault: version 0: PDEPEND="stub/stub4[!foo?]": USE flag 'foo' missing from package: [ stub/stub4-0 ]
-  MissingUseDepDefault: version 0: RDEPEND="stub/stub2[-foo]": USE flag 'foo' missing from package: [ stub/stub2-0 ]
+  MissingUseDepDefault: version 0: [PG0021] BDEPEND="stub/stub3[foo?]": USE flag 'foo' missing from package: [ stub/stub3-0 ]
+  MissingUseDepDefault: version 0: [PG0021] DEPEND="stub/stub1[foo]": USE flag 'foo' missing from package: [ stub/stub1-0 ]
+  MissingUseDepDefault: version 0: [PG0021] PDEPEND="stub/stub4[!foo?]": USE flag 'foo' missing from package: [ stub/stub4-0 ]
+  MissingUseDepDefault: version 0: [PG0021] RDEPEND="stub/stub2[-foo]": USE flag 'foo' missing from package: [ stub/stub2-0 ]

--- a/tests/data/repos/standalone/EapiCheck/DeprecatedEapi/expected
+++ b/tests/data/repos/standalone/EapiCheck/DeprecatedEapi/expected
@@ -1,2 +1,2 @@
 EapiCheck/DeprecatedEapi
-  DeprecatedEapi: version 0: uses deprecated EAPI 5
+  DeprecatedEapi: version 0: [PG1001] uses deprecated EAPI 5

--- a/tests/data/repos/standalone/EclassUsageCheck/DeprecatedEclass/expected
+++ b/tests/data/repos/standalone/EclassUsageCheck/DeprecatedEclass/expected
@@ -1,2 +1,2 @@
 EclassUsageCheck/DeprecatedEclass
-  DeprecatedEclass: version 0: uses deprecated eclass: [ versionator (migrate to ver_* functions from EAPI 7) ]
+  DeprecatedEclass: version 0: [PG1003] uses deprecated eclass: [ versionator (migrate to ver_* functions from EAPI 7) ]

--- a/tests/data/repos/standalone/HomepageCheck/BadHomepage/expected
+++ b/tests/data/repos/standalone/HomepageCheck/BadHomepage/expected
@@ -1,5 +1,5 @@
 HomepageCheck/BadHomepage
-  BadHomepage: version 0: HOMEPAGE empty/unset
-  BadHomepage: version 1: HOMEPAGE='github.com/pkgcore/pkgcheck' lacks protocol
-  BadHomepage: version 2: HOMEPAGE='gopher://github.com/pkgcore/pkgcheck' uses unsupported protocol 'gopher'
-  BadHomepage: version 3: unspecific HOMEPAGE: https://www.gentoo.org
+  BadHomepage: version 0: [PG0702] HOMEPAGE empty/unset
+  BadHomepage: version 1: [PG0702] HOMEPAGE='github.com/pkgcore/pkgcheck' lacks protocol
+  BadHomepage: version 2: [PG0702] HOMEPAGE='gopher://github.com/pkgcore/pkgcheck' uses unsupported protocol 'gopher'
+  BadHomepage: version 3: [PG0702] unspecific HOMEPAGE: https://www.gentoo.org

--- a/tests/data/repos/standalone/LocalUseCheck/UnderscoreInUseFlag/expected
+++ b/tests/data/repos/standalone/LocalUseCheck/UnderscoreInUseFlag/expected
@@ -1,2 +1,2 @@
 LocalUseCheck/UnderscoreInUseFlag
-  UnderscoreInUseFlag: USE flag 'foo_bar' uses reserved underscore character
+  UnderscoreInUseFlag: [PG0803] USE flag 'foo_bar' uses reserved underscore character

--- a/tests/data/repos/standalone/MissingSlotDepCheck/MissingSlotDep/expected
+++ b/tests/data/repos/standalone/MissingSlotDepCheck/MissingSlotDep/expected
@@ -1,2 +1,2 @@
 MissingSlotDepCheck/MissingSlotDep
-  MissingSlotDep: version 0: 'stub/slotted' matches more than one slot: [ 0, 1 ]
+  MissingSlotDep: version 0: [PG0011] 'stub/slotted' matches more than one slot: [ 0, 1 ]

--- a/tests/data/repos/standalone/RawEbuildCheck/HomepageInSrcUri/expected
+++ b/tests/data/repos/standalone/RawEbuildCheck/HomepageInSrcUri/expected
@@ -1,2 +1,2 @@
 RawEbuildCheck/HomepageInSrcUri
-  HomepageInSrcUri: version 0: ${HOMEPAGE} in SRC_URI
+  HomepageInSrcUri: version 0: [PG0104] ${HOMEPAGE} in SRC_URI

--- a/tests/data/repos/standalone/RawEbuildCheck/VariableInHomepage/expected
+++ b/tests/data/repos/standalone/RawEbuildCheck/VariableInHomepage/expected
@@ -1,2 +1,2 @@
 RawEbuildCheck/VariableInHomepage
-  VariableInHomepage: version 0: HOMEPAGE includes variable: ${PN}
+  VariableInHomepage: version 0: [PG0103] HOMEPAGE includes variable: ${PN}

--- a/tests/data/repos/standalone/RestrictTestCheck/MissingTestRestrict/expected
+++ b/tests/data/repos/standalone/RestrictTestCheck/MissingTestRestrict/expected
@@ -1,2 +1,2 @@
 RestrictTestCheck/MissingTestRestrict
-  MissingTestRestrict: version 0: missing RESTRICT="!test? ( test )" with IUSE=test
+  MissingTestRestrict: version 0: [PG0703] missing RESTRICT="!test? ( test )" with IUSE=test


### PR DESCRIPTION
Include Policy Guide identifiers in reports. This is going to make it easier to refer to documentation. Long term I also plan to introduce `policy.conf` file to control checks from the repo.