### PR TITLE
DeprecatedEclassCheck: mark cmake-utils as deprecated

### DIFF
--- a/src/pkgcheck/checks/eclass.py
+++ b/src/pkgcheck/checks/eclass.py
@@ -61,6 +61,7 @@ class EclassUsageCheck(Check):
         'bash-completion': 'bash-completion-r1',
         'boost-utils': None,
         'clutter': 'gnome2',
+        'cmake-utils': 'cmake',
         'confutils': None,
         'darcs': None,
         'distutils': 'distutils-r1',


### PR DESCRIPTION
Hi, it looks like that message is missing despite being present in repoman, see https://github.com/gentoo/portage/pull/554.