### PR TITLE
checks.repo_metadata: Detect moves to self

### DIFF
--- a/src/pkgcheck/checks/repo_metadata.py
+++ b/src/pkgcheck/checks/repo_metadata.py
@@ -56,6 +56,18 @@ class OldPackageUpdate(results.ProfilesResult, results.Warning):
         return f"{self.pkg!r} unavailable: old update line: {' '.join(self.updates)!r}"
 
 
+class MoveToSelfPackageUpdate(results.ProfilesResult, results.Warning):
+    """Move entry to the same package/slot (source == target)."""
+
+    def __init__(self, updates):
+        super().__init__()
+        self.updates = tuple(updates)
+
+    @property
+    def desc(self):
+        return f"update line moves to the same package/slot: {' '.join(self.updates)!r}"
+
+
 class MovedPackageUpdate(results.ProfilesResult, results.LogWarning):
     """Entry for package already moved in profiles/updates files."""
 
@@ -72,6 +84,7 @@ class PackageUpdatesCheck(Check):
     known_results = frozenset([
         MultiMovePackageUpdate, OldMultiMovePackageUpdate,
         OldPackageUpdate, MovedPackageUpdate, BadPackageUpdate,
+        MoveToSelfPackageUpdate,
     ])
 
     def __init__(self, *args):
@@ -106,17 +119,21 @@ class PackageUpdatesCheck(Check):
             else:
                 # scan updates for old entries with removed packages
                 for x in move_updates:
-                    _, _old, new = x
+                    _, old, new = x
                     if not self.repo.match(new):
                         old_move_updates[new] = x
+                    if old == new:
+                        yield MoveToSelfPackageUpdate(map(str, x))
 
             # scan updates for old entries with removed packages
             for x in slotmove_updates:
                 _, pkg, newslot = x
+                orig_line = ('slotmove', str(pkg)[:-(len(pkg.slot) + 1)], pkg.slot, newslot)
                 if not self.repo.match(pkg.unversioned_atom):
                     # reproduce updates file line data for result output
-                    x = ('slotmove', str(pkg)[:-(len(pkg.slot) + 1)], pkg.slot, newslot)
-                    old_slotmove_updates[pkg.key] = x
+                    old_slotmove_updates[pkg.key] = orig_line
+                if pkg.slot == newslot:
+                    yield MoveToSelfPackageUpdate(map(str, orig_line))
 
         for pkg, v in multi_move_updates.items():
             orig_pkg, moves = v

--- a/tests/module/checks/test_repo_metadata.py
+++ b/tests/module/checks/test_repo_metadata.py
@@ -110,3 +110,21 @@ class TestPackageUpdatesCheck(misc.Tmpdir, misc.ReportTestCase):
         assert r.pkg == 'dev-util/foo'
         assert r.moves == ('dev-util/foo', 'dev-util/bar', 'dev-util/blah')
         assert "'dev-util/foo': multi-move update" in str(r)
+
+    def test_move_to_self_pkg_update(self):
+        update = ['move dev-util/foo dev-util/foo']
+        pkgs = ('dev-util/foo-0',)
+        updates = {'1Q-2020': update}
+        r = self.assertReport(self.mk_check(pkgs=pkgs, **updates), [])
+        assert isinstance(r, repo_metadata.MoveToSelfPackageUpdate)
+        assert r.updates == ('move', 'dev-util/foo', 'dev-util/foo')
+        assert "update line moves to the same package/slot" in str(r)
+
+    def test_slot_move_to_self_pkg_update(self):
+        update = ['slotmove dev-util/foo 0 0']
+        pkgs = ('dev-util/foo-0',)
+        updates = {'1Q-2020': update}
+        r = self.assertReport(self.mk_check(pkgs=pkgs, **updates), [])
+        assert isinstance(r, repo_metadata.MoveToSelfPackageUpdate)
+        assert r.updates == ('slotmove', 'dev-util/foo', '0', '0')
+        assert "update line moves to the same package/slot" in str(r)


### PR DESCRIPTION
Detect meaningless move/slotmove entries that use the same package/slot
as both source and target.  This will hopefully catch sed mistakes.