### PR TITLE
python: Fix treating python3.10 as newer than python3.9

### DIFF
--- a/testdata/data/repos/python/PythonCompatCheck/PythonCompatUpdate/expected.json
+++ b/testdata/data/repos/python/PythonCompatCheck/PythonCompatUpdate/expected.json
@@ -1,3 +1,3 @@
-{"__class__": "PythonCompatUpdate", "category": "PythonCompatCheck", "package": "PythonCompatUpdate", "version": "0", "updates": ["python3_8", "python3_9"]}
-{"__class__": "PythonCompatUpdate", "category": "PythonCompatCheck", "package": "PythonCompatUpdate", "version": "1", "updates": ["python3_9"]}
-{"__class__": "PythonCompatUpdate", "category": "PythonCompatCheck", "package": "PythonCompatUpdate", "version": "2", "updates": ["python3_9"]}
+{"__class__": "PythonCompatUpdate", "category": "PythonCompatCheck", "package": "PythonCompatUpdate", "version": "0", "updates": ["python3_8", "python3_9", "python3_10"]}
+{"__class__": "PythonCompatUpdate", "category": "PythonCompatCheck", "package": "PythonCompatUpdate", "version": "1", "updates": ["python3_9", "python3_10"]}
+{"__class__": "PythonCompatUpdate", "category": "PythonCompatCheck", "package": "PythonCompatUpdate", "version": "2", "updates": ["python3_9", "python3_10"]}

--- a/testdata/data/repos/python/PythonCompatCheck/PythonCompatUpdate/fix.patch
+++ b/testdata/data/repos/python/PythonCompatCheck/PythonCompatUpdate/fix.patch
@@ -4,7 +4,7 @@ diff -Naur python/PythonCompatCheck/PythonCompatUpdate/PythonCompatUpdate-0.ebui
 @@ -1,5 +1,5 @@
  EAPI=7
 -PYTHON_COMPAT=( python3_7 )
-+PYTHON_COMPAT=( python3_{7..9} )
++PYTHON_COMPAT=( python3_{7..10} )
  
  inherit python-r1
  
@@ -14,7 +14,7 @@ diff -Naur python/PythonCompatCheck/PythonCompatUpdate/PythonCompatUpdate-1.ebui
 @@ -1,5 +1,5 @@
  EAPI=7
 -PYTHON_COMPAT=( python3_{7,8} )
-+PYTHON_COMPAT=( python3_{7..9} )
++PYTHON_COMPAT=( python3_{7..10} )
  
  inherit python-single-r1
  
@@ -24,7 +24,7 @@ diff -Naur python/PythonCompatCheck/PythonCompatUpdate/PythonCompatUpdate-2.ebui
 @@ -1,5 +1,5 @@
  EAPI=7
 -PYTHON_COMPAT=( python3_{7,8} )
-+PYTHON_COMPAT=( python3_{7..9} )
++PYTHON_COMPAT=( python3_{7..10} )
  
  inherit python-any-r1
  

--- a/testdata/repos/python/profiles/desc/python_single_target.desc
+++ b/testdata/repos/python/profiles/desc/python_single_target.desc
@@ -3,4 +3,5 @@ python2_7 - Build with Python 2.7
 python3_7 - Build with Python 3.7
 python3_8 - Build with Python 3.8
 python3_9 - Build with Python 3.9
+python3_10 - Build with Python 3.10
 pypy3 - Build for PyPy3 only

--- a/testdata/repos/python/profiles/desc/python_targets.desc
+++ b/testdata/repos/python/profiles/desc/python_targets.desc
@@ -3,4 +3,5 @@ python2_7 - Build with Python 2.7
 python3_7 - Build with Python 3.7
 python3_8 - Build with Python 3.8
 python3_9 - Build with Python 3.9
+python3_10 - Build with Python 3.10
 pypy3 - Build for PyPy3 only

--- a/testdata/repos/python/stub/python-dep1/python-dep1-0.ebuild
+++ b/testdata/repos/python/stub/python-dep1/python-dep1-0.ebuild
@@ -1,5 +1,5 @@
 EAPI=7
-PYTHON_COMPAT=( python2_7 python3_{7,8,9} )
+PYTHON_COMPAT=( python2_7 python3_{7,8,9,10} )
 
 inherit python-r1
 

--- a/testdata/repos/python/stub/python-dep2/python-dep2-0.ebuild
+++ b/testdata/repos/python/stub/python-dep2/python-dep2-0.ebuild
@@ -1,5 +1,5 @@
 EAPI=7
-PYTHON_COMPAT=( python2_7 python3_{7,8,9} )
+PYTHON_COMPAT=( python2_7 python3_{7,8,9,10} )
 
 inherit python-r1
 


### PR DESCRIPTION
Fix the sorting logic to use a combined lexical-numerical sort, in order
to sort python3.10 as newer than python3.9.  This fixes
PythonCompatUpdate check.