### PR TITLE
RepoProfilesCheck: use inheritance instead of lexical EAPI name cmp

### DIFF
--- a/src/pkgcheck/checks/profiles.py
+++ b/src/pkgcheck/checks/profiles.py
@@ -411,9 +411,7 @@ class RepoProfilesCheck(RepoCheck):
                 continue
             for parent in profile.stack:
                 seen_profile_dirs.update(dir_parents(parent.name))
-                # flag lagging profile EAPIs -- assumes EAPIs are sequentially
-                # numbered which should be the case for the gentoo repo
-                if (self.options.gentoo_repo and str(profile.eapi) < str(parent.eapi)):
+                if profile.eapi is not parent.eapi and profile.eapi in parent.eapi.inherits:
                     lagging_profile_eapi[profile].append(parent)
 
         for profile, parents in lagging_profile_eapi.items():


### PR DESCRIPTION
Use profile inheritance to determine whether the 'newer' EAPI is
a superset of an 'older' EAPI rather than lexical comparison.