### PR TITLE
GitCommitMessageCheck: Allow version to be prefixed with "v"

### DIFF
--- a/src/pkgcheck/checks/git.py
+++ b/src/pkgcheck/checks/git.py
@@ -577,7 +577,7 @@ class GitCommitMessageCheck(GentooRepoCheck, GitCommitsCheck):
                 # check for version in summary for singular, non-revision bumps
                 if len(commit.pkgs['A']) == 1:
                     atom = next(iter(commit.pkgs['A']))
-                    if not atom.revision and not re.match(rf'^.+\b{re.escape(atom.version)}\b.*$', summary):
+                    if not atom.revision and not re.match(rf'^.+\bv?{re.escape(atom.version)}\b.*$', summary):
                         error = f'summary missing package version {atom.version!r}'
                         yield BadCommitSummary(error, summary, commit=commit)
             else:

--- a/tests/checks/test_git.py
+++ b/tests/checks/test_git.py
@@ -300,6 +300,10 @@ class TestGitCommitMessageRepoCheck(ReportTestCase):
         self.child_repo.create_ebuild('cat/pkg-6-r1')
         self.child_git_repo.add_all('cat/pkg: revision bump', signoff=True)
         self.init_check()
+        # allow vVERSION
+        self.child_repo.create_ebuild('cat/pkg-7')
+        self.child_git_repo.add_all('cat/pkg: bump to v7', signoff=True)
+        self.init_check()
         results = self.assertReports(self.check, self.source)
         r1 = git_mod.BadCommitSummary(
             "summary missing 'cat/pkg' package prefix",


### PR DESCRIPTION
Closes: https://github.com/pkgcore/pkgcheck/issues/344