### PR TITLE
Add a check for eclasses calling EXPORT_FUNCTIONS before inherit

### DIFF
--- a/testdata/data/repos/eclass/EclassParseCheck/EclassExportFuncsBeforeInherit/expected.json
+++ b/testdata/data/repos/eclass/EclassParseCheck/EclassExportFuncsBeforeInherit/expected.json
@@ -1,0 +1,1 @@
+{"__class__": "EclassExportFuncsBeforeInherit", "eclass": "export-funcs-before-inherit", "export_line": 7, "inherit_line": 9}

--- a/testdata/data/repos/eclass/EclassParseCheck/EclassExportFuncsBeforeInherit/fix.patch
+++ b/testdata/data/repos/eclass/EclassParseCheck/EclassExportFuncsBeforeInherit/fix.patch
@@ -1,0 +1,16 @@
+diff -Naur eclass/eclass/export-funcs-before-inherit.eclass fixed/eclass/export-funcs-before-inherit.eclass
+--- eclass/eclass/export-funcs-before-inherit.eclass	2021-08-28 18:40:14.244787360 +0200
++++ fixed/eclass/export-funcs-before-inherit.eclass	2021-08-28 18:51:30.540581468 +0200
+@@ -4,10 +4,10 @@
+ # @SUPPORTED_EAPIS: 0 1 2 3 4 5 6 7
+ # @BLURB: Stub eclass for testing EclassExportFuncsBeforeInherit.
+ 
+-EXPORT_FUNCTIONS src_prepare
+-
+ inherit another-src_prepare
+ 
++EXPORT_FUNCTIONS src_prepare
++
+ # @FUNCTION: export-funcs-before-inherit_src_prepare
+ # @DESCRIPTION:
+ # My src_prepare.

--- a/testdata/repos/eclass/EclassParseCheck/EclassExportFuncsBeforeInherit/EclassExportFuncsBeforeInherit-1.ebuild
+++ b/testdata/repos/eclass/EclassParseCheck/EclassExportFuncsBeforeInherit/EclassExportFuncsBeforeInherit-1.ebuild
@@ -1,0 +1,8 @@
+EAPI=5
+
+inherit export-funcs-before-inherit
+
+DESCRIPTION="Ebuild using an eclass calling EXPORT_FUNCTIONS before inherit"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"

--- a/testdata/repos/eclass/eclass/another-src_prepare.eclass
+++ b/testdata/repos/eclass/eclass/another-src_prepare.eclass
@@ -1,0 +1,14 @@
+# @ECLASS: another-src_prepare.eclass
+# @MAINTAINER:
+# Random Person <maintainer@random.email>
+# @SUPPORTED_EAPIS: 0 1 2 3 4 5 6 7
+# @BLURB: Inherited eclass for testing EclassExportFuncsBeforeInherit.
+
+EXPORT_FUNCTIONS src_prepare
+
+# @FUNCTION: another-src_prepare_src_prepare
+# @DESCRIPTION:
+# Another src_prepare.
+another-src_prepare_src_prepare() {
+	:
+}

--- a/testdata/repos/eclass/eclass/export-funcs-before-inherit.eclass
+++ b/testdata/repos/eclass/eclass/export-funcs-before-inherit.eclass
@@ -1,0 +1,16 @@
+# @ECLASS: export-funcs-before-inherit.eclass
+# @MAINTAINER:
+# Random Person <maintainer@random.email>
+# @SUPPORTED_EAPIS: 0 1 2 3 4 5 6 7
+# @BLURB: Stub eclass for testing EclassExportFuncsBeforeInherit.
+
+EXPORT_FUNCTIONS src_prepare
+
+inherit another-src_prepare
+
+# @FUNCTION: export-funcs-before-inherit_src_prepare
+# @DESCRIPTION:
+# My src_prepare.
+export-funcs-before-inherit_src_prepare() {
+	:
+}


### PR DESCRIPTION
The behavior for handling EXPORT_FUNCTIONS before inherit is not
consistent across package managers.  Enforce calling it after inherit
to guarantee consistent behavior.