### PR TITLE
Add initial test for IndirectInherits test

### DIFF
--- a/testdata/data/repos/eclass/InheritsCheck/IndirectInherits/expected.json
+++ b/testdata/data/repos/eclass/InheritsCheck/IndirectInherits/expected.json
@@ -1,0 +1,1 @@
+{"__class__": "IndirectInherits", "category": "InheritsCheck", "package": "IndirectInherits", "version": "0", "eclass": "inherit", "lineno": 11, "usage": "inherit_public_func"}

--- a/testdata/data/repos/eclass/InheritsCheck/IndirectInherits/fix.patch
+++ b/testdata/data/repos/eclass/InheritsCheck/IndirectInherits/fix.patch
@@ -1,0 +1,11 @@
+diff -Naur eclass/InheritsCheck/IndirectInherits/IndirectInherits-0.ebuild fixed/InheritsCheck/IndirectInherits/IndirectInherits-0.ebuild
+--- eclass/InheritsCheck/IndirectInherits/IndirectInherits-0.ebuild	2021-08-31 16:26:55.157158862 +0200
++++ fixed/InheritsCheck/IndirectInherits/IndirectInherits-0.ebuild	2021-08-31 16:28:12.282123172 +0200
+@@ -1,6 +1,6 @@
+ EAPI=7
+ 
+-inherit indirect-inherit
++inherit inherit indirect-inherit
+ 
+ DESCRIPTION="Ebuild relying on indirect inherit"
+ HOMEPAGE="https://github.com/pkgcore/pkgcheck"

--- a/testdata/repos/eclass/InheritsCheck/IndirectInherits/IndirectInherits-0.ebuild
+++ b/testdata/repos/eclass/InheritsCheck/IndirectInherits/IndirectInherits-0.ebuild
@@ -1,0 +1,13 @@
+EAPI=7
+
+inherit indirect-inherit
+
+DESCRIPTION="Ebuild relying on indirect inherit"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"
+
+src_prepare() {
+	inherit_public_func
+	indirect_inherit_public_func
+}

--- a/testdata/repos/eclass/eclass/indirect-inherit.eclass
+++ b/testdata/repos/eclass/eclass/indirect-inherit.eclass
@@ -1,0 +1,13 @@
+# @ECLASS: indirect-inherit.eclass
+# @MAINTAINER:
+# Random Person <maintainer@random.email>
+# @SUPPORTED_EAPIS: 0 1 2 3 4 5 6 7
+# @BLURB: Stub eclass for testing InheritsCheck.
+
+inherit inherit
+
+# @FUNCTION: indirect_inherit_public_func
+# @USAGE:
+# @DESCRIPTION:
+# Public stub function.
+indirect_inherit_public_func() { :; }


### PR DESCRIPTION
Add an initial test verifying that IndirectInherits is reported
for the most basic test case.  Further tests will follow once @PROVIDES
support lands in pkgcore.