### PR TITLE
new check: calls to eend without an argument

### DIFF
--- a/src/pkgcheck/checks/codingstyle.py
+++ b/src/pkgcheck/checks/codingstyle.py
@@ -79,6 +79,29 @@ class BadCommandsCheck(Check):
                     yield DeprecatedEapiCommand(name, line=call, lineno=lineno+1, eapi=pkg.eapi, pkg=pkg)
 
 
+class EendMissingArg(results.LineResult, results.Warning):
+    """Ebuild calls eend with no arguments."""
+
+    @property
+    def desc(self):
+        return f'eend with no arguments, on line {self.lineno}'
+
+
+class EendMissingArgCheck(Check):
+    """Scan an ebuild for calls to eend with no arguments."""
+
+    _source = sources.EbuildParseRepoSource
+    known_results = frozenset([EendMissingArg])
+
+    def feed(self, pkg):
+        for func_node, _ in bash.func_query.captures(pkg.tree.root_node):
+            for node, _ in bash.cmd_query.captures(func_node):
+                line = pkg.node_str(node)
+                if line == "eend":
+                    lineno, _ = node.start_point
+                    yield EendMissingArg(line=line, lineno=lineno+1, pkg=pkg)
+
+
 class MissingSlash(results.VersionResult, results.Error):
     """Ebuild uses a path variable missing a trailing slash."""
 

--- a/testdata/data/repos/standalone/EendMissingArgCheck/EendMissingArg/expected.json
+++ b/testdata/data/repos/standalone/EendMissingArgCheck/EendMissingArg/expected.json
@@ -1,0 +1,1 @@
+{"__class__": "EendMissingArg", "category": "EendMissingArgCheck", "package": "EendMissingArg", "version": "0", "line": "eend", "lineno": 10}

--- a/testdata/data/repos/standalone/EendMissingArgCheck/EendMissingArg/fix.patch
+++ b/testdata/data/repos/standalone/EendMissingArgCheck/EendMissingArg/fix.patch
@@ -1,0 +1,9 @@
+--- standalone/EendMissingArgCheck/EendMissingArg/EendMissingArg-0.ebuild	2022-04-20 14:25:14.385255909 +0200
++++ fixed/EendMissingArgCheck/EendMissingArg/EendMissingArg-0.ebuild	2022-04-20 15:42:04.363051160 +0200
+@@ -7,5 +7,5 @@
+ 
+ src_install() {
+ 	ebegin "installing"
+-	eend
++	eend $?
+ }

--- a/testdata/repos/standalone/EendMissingArgCheck/EendMissingArg/EendMissingArg-0.ebuild
+++ b/testdata/repos/standalone/EendMissingArgCheck/EendMissingArg/EendMissingArg-0.ebuild
@@ -1,0 +1,11 @@
+EAPI=8
+
+DESCRIPTION="Ebuild calling eend without an argument"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+LICENSE="BSD"
+SLOT="0"
+
+src_install() {
+	ebegin "installing"
+	eend
+}


### PR DESCRIPTION
Calls to eend should always have an argument.

Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>