### PR TITLE
new check: LICENSE should not contain variables

### DIFF
--- a/testdata/data/repos/standalone/MetadataVarCheck/ReferenceInMetadataVar/expected.json
+++ b/testdata/data/repos/standalone/MetadataVarCheck/ReferenceInMetadataVar/expected.json
@@ -1,2 +1,5 @@
 {"__class__": "ReferenceInMetadataVar", "category": "MetadataVarCheck", "package": "ReferenceInMetadataVar", "version": "0", "variable": "HOMEPAGE", "refs": ["${PN}"]}
 {"__class__": "ReferenceInMetadataVar", "category": "MetadataVarCheck", "package": "ReferenceInMetadataVar", "version": "1", "variable": "KEYWORDS", "refs": ["${ARCH}"]}
+{"__class__": "ReferenceInMetadataVar", "category": "MetadataVarCheck", "package": "ReferenceInMetadataVar", "version": "2", "variable": "LICENSE", "refs": ["${MY_LICENSE}"]}
+{"__class__": "ReferenceInMetadataVar", "category": "MetadataVarCheck", "package": "ReferenceInMetadataVar", "version": "3", "variable": "LICENSE", "refs": ["${MY_LICENSE}"]}
+{"__class__": "ReferenceInMetadataVar", "category": "MetadataVarCheck", "package": "ReferenceInMetadataVar", "version": "4", "variable": "LICENSE", "refs": ["${LICENSE/B/B}"]}

--- a/testdata/data/repos/standalone/MetadataVarCheck/ReferenceInMetadataVar/fix.patch
+++ b/testdata/data/repos/standalone/MetadataVarCheck/ReferenceInMetadataVar/fix.patch
@@ -18,3 +18,36 @@ diff -Naur standalone/MetadataVarCheck/ReferenceInMetadataVar/ReferenceInMetadat
 -ARCH="~x86"
 -KEYWORDS="~amd64 ${ARCH}"
 +KEYWORDS="~amd64 ~x86"
+diff -Naur standalone/MetadataVarCheck/ReferenceInMetadataVar/ReferenceInMetadataVar-2.ebuild fixed/MetadataVarCheck/ReferenceInMetadataVar/ReferenceInMetadataVar-2.ebuild
+--- standalone/MetadataVarCheck/ReferenceInMetadataVar/ReferenceInMetadataVar-2.ebuild	2022-04-30 20:58:05.075839682 +0200
++++ fixed/MetadataVarCheck/ReferenceInMetadataVar/ReferenceInMetadataVar-2.ebuild.fixed	2022-04-30 20:57:57.498766323 +0200
+@@ -1,7 +1,6 @@
+ DESCRIPTION="Ebuild with variable in LICENSE"
+ HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+ SLOT="0"
+-MY_LICENSE="BSD"
+-LICENSE="${MY_LICENSE}"
++LICENSE="BSD"
+ LICENSE="${LICENSE} BSD"
+ KEYWORDS="~amd64 ~x86"
+diff -Naur standalone/MetadataVarCheck/ReferenceInMetadataVar/ReferenceInMetadataVar-3.ebuild fixed/MetadataVarCheck/ReferenceInMetadataVar/ReferenceInMetadataVar-3.ebuild
+--- standalone/MetadataVarCheck/ReferenceInMetadataVar/ReferenceInMetadataVar-3.ebuild	2022-04-30 20:58:05.075839682 +0200
++++ fixed/MetadataVarCheck/ReferenceInMetadataVar/ReferenceInMetadataVar-3.ebuild.fixed	2022-04-30 20:57:57.498766323 +0200
+@@ -1,7 +1,6 @@
+ DESCRIPTION="Ebuild with variable in LICENSE"
+ HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+ SLOT="0"
+-MY_LICENSE="BSD"
+ LICENSE=""
+-LICENSE+="${MY_LICENSE}"
++LICENSE+="BSD"
+ KEYWORDS="~amd64 ~x86"
+diff -Naur standalone/MetadataVarCheck/ReferenceInMetadataVar/ReferenceInMetadataVar-4.ebuild fixed/MetadataVarCheck/ReferenceInMetadataVar/ReferenceInMetadataVar-4.ebuild
+--- standalone/MetadataVarCheck/ReferenceInMetadataVar/ReferenceInMetadataVar-4.ebuild	2022-04-30 20:58:05.075839682 +0200
++++ fixed/MetadataVarCheck/ReferenceInMetadataVar/ReferenceInMetadataVar-4.ebuild.fixed	2022-04-30 20:57:57.498766323 +0200
+@@ -2,5 +2,4 @@
+ HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+ SLOT="0"
+ LICENSE="BSD"
+-LICENSE="${LICENSE} ${LICENSE/B/B}"
+ KEYWORDS="~amd64 ~x86"

--- a/testdata/repos/standalone/MetadataVarCheck/ReferenceInMetadataVar/ReferenceInMetadataVar-2.ebuild
+++ b/testdata/repos/standalone/MetadataVarCheck/ReferenceInMetadataVar/ReferenceInMetadataVar-2.ebuild
@@ -1,0 +1,7 @@
+DESCRIPTION="Ebuild with variable in LICENSE"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+MY_LICENSE="BSD"
+LICENSE="${MY_LICENSE}"
+LICENSE="${LICENSE} BSD"
+KEYWORDS="~amd64 ~x86"

--- a/testdata/repos/standalone/MetadataVarCheck/ReferenceInMetadataVar/ReferenceInMetadataVar-3.ebuild
+++ b/testdata/repos/standalone/MetadataVarCheck/ReferenceInMetadataVar/ReferenceInMetadataVar-3.ebuild
@@ -1,0 +1,7 @@
+DESCRIPTION="Ebuild with variable in LICENSE"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+MY_LICENSE="BSD"
+LICENSE=""
+LICENSE+="${MY_LICENSE}"
+KEYWORDS="~amd64 ~x86"

--- a/testdata/repos/standalone/MetadataVarCheck/ReferenceInMetadataVar/ReferenceInMetadataVar-4.ebuild
+++ b/testdata/repos/standalone/MetadataVarCheck/ReferenceInMetadataVar/ReferenceInMetadataVar-4.ebuild
@@ -1,0 +1,6 @@
+DESCRIPTION="Ebuild with variable in LICENSE"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"
+LICENSE="${LICENSE} ${LICENSE/B/B}"
+KEYWORDS="~amd64 ~x86"


### PR DESCRIPTION
Extend MetadataVarCheck with a new method checking the LICENSE variable
for other variables. The only exception is LICENSE itself. The check
accepts occurrences of $LICENSE and ${LICENSE}.

Closes: https://github.com/pkgcore/pkgcheck/issues/366
Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>