### PR TITLE
new check: usage of deprecated variables or functions

### DIFF
--- a/testdata/data/repos/standalone/EclassUsageCheck/DeprecatedEclassFunction/expected.json
+++ b/testdata/data/repos/standalone/EclassUsageCheck/DeprecatedEclassFunction/expected.json
@@ -1,0 +1,2 @@
+{"__class__": "DeprecatedEclassFunction", "category": "EclassUsageCheck", "package": "DeprecatedEclassFunction", "version": "0", "line": "go-module_set_globals", "lineno": 10, "function": "go-module_set_globals", "replacement": "use tarball"}
+{"__class__": "DeprecatedEclassFunction", "category": "EclassUsageCheck", "package": "DeprecatedEclassFunction", "version": "0", "line": "go-module_setup_proxy", "lineno": 11, "function": "go-module_setup_proxy", "replacement": null}

--- a/testdata/data/repos/standalone/EclassUsageCheck/DeprecatedEclassVariable/expected.json
+++ b/testdata/data/repos/standalone/EclassUsageCheck/DeprecatedEclassVariable/expected.json
@@ -1,0 +1,2 @@
+{"__class__": "DeprecatedEclassVariable", "category": "EclassUsageCheck", "package": "DeprecatedEclassVariable", "version": "0", "line": "EGO_SUM", "lineno": 10, "variable": "EGO_SUM", "replacement": "use tarball"}
+{"__class__": "DeprecatedEclassVariable", "category": "EclassUsageCheck", "package": "DeprecatedEclassVariable", "version": "0", "line": "_GOMODULE_GOPROXY_BASEURI", "lineno": 11, "variable": "_GOMODULE_GOPROXY_BASEURI", "replacement": null}

--- a/testdata/repos/standalone/EclassUsageCheck/DeprecatedEclassFunction/DeprecatedEclassFunction-0.ebuild
+++ b/testdata/repos/standalone/EclassUsageCheck/DeprecatedEclassFunction/DeprecatedEclassFunction-0.ebuild
@@ -1,0 +1,12 @@
+EAPI=8
+
+inherit go-module
+
+DESCRIPTION="Ebuild with deprecated function calls"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"
+
+go-module_set_globals
+go-module_setup_proxy
+ego stub

--- a/testdata/repos/standalone/EclassUsageCheck/DeprecatedEclassVariable/DeprecatedEclassVariable-0.ebuild
+++ b/testdata/repos/standalone/EclassUsageCheck/DeprecatedEclassVariable/DeprecatedEclassVariable-0.ebuild
@@ -1,0 +1,12 @@
+EAPI=8
+
+inherit go-module
+
+DESCRIPTION="Ebuild with deprecated variable usage"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"
+
+EGO_SUM="stub"
+_GOMODULE_GOPROXY_BASEURI="stub"
+GO_OPTIONAL=1

--- a/testdata/repos/standalone/eclass/go-module.eclass
+++ b/testdata/repos/standalone/eclass/go-module.eclass
@@ -1,0 +1,40 @@
+# go-module
+
+# @ECLASS_VARIABLE: EGO_SUM
+# @DEPRECATED: use tarball
+# @DESCRIPTION:
+# var
+
+# @ECLASS_VARIABLE: _GOMODULE_GOPROXY_BASEURI
+# @DEPRECATED: none
+# @DESCRIPTION:
+# var
+
+# @ECLASS_VARIABLE: GO_OPTIONAL
+# @DEFAULT_UNSET
+# @DESCRIPTION:
+# var
+
+# @FUNCTION: ego
+# @USAGE: [<args>...]
+# @DESCRIPTION:
+# func
+ego() {
+	:
+}
+
+# @FUNCTION: go-module_setup_proxy
+# @DEPRECATED: none
+# @DESCRIPTION:
+# func
+go-module_setup_proxy() {
+	:
+}
+
+# @FUNCTION: go-module_set_globals
+# @DEPRECATED: use tarball
+# @DESCRIPTION:
+# func
+go-module_set_globals() {
+	:
+}


### PR DESCRIPTION
Resolves: https://github.com/pkgcore/pkgcheck/issues/373
Resolves: https://github.com/pkgcore/pkgcheck/issues/374

<details>
<summary>Example output</summary>

```
app-admin/gopass
  UnstableOnly: for arches: [ ppc64, x86 ], all versions are unstable: [ 1.12.6, 1.12.7, 1.13.0 ]
  DeprecatedEclassVariable: version 1.12.6: uses deprecated variable on line 8: EGO_SUM (no replacement)
  DeprecatedEclassFunction: version 1.12.6: uses deprecated function on line 494: go-module_set_globals (no replacement)
  PotentialStable: version 1.12.6: slot(0), stabled arch: [ amd64 ], potentials: [ ~ppc64, ~x86 ]
  DeprecatedEclassVariable: version 1.12.7: uses deprecated variable on line 8: EGO_SUM (no replacement)
  DeprecatedEclassFunction: version 1.12.7: uses deprecated function on line 498: go-module_set_globals (no replacement)
  RedundantVersion: version 1.12.7: slot(0) keywords are overshadowed by version: 1.13.0
  DeprecatedEclassVariable: version 1.13.0: uses deprecated variable on line 8: EGO_SUM (no replacement)
  DeprecatedEclassFunction: version 1.13.0: uses deprecated function on line 510: go-module_set_globals (no replacement)
  StableRequest: version 1.13.0: slot(0) no change in 146 days for unstable keyword: [ ~amd64 ]
```
</details>

---

TODO:

- [x] Add tests for this new check