### PR TITLE
new check: variables that should be quoted

### DIFF
--- a/testdata/data/repos/eclass/EclassUnquotedVariablesCheck/EclassUnquotedVariable/expected.json
+++ b/testdata/data/repos/eclass/EclassUnquotedVariablesCheck/EclassUnquotedVariable/expected.json
@@ -1,0 +1,1 @@
+{"__class__": "EclassUnquotedVariable", "eclass": "unquotedvariable", "variable": "DISTDIR", "lines": [19]}

--- a/testdata/data/repos/standalone/EbuildUnquotedVariablesCheck/EbuildUnquotedVariable/expected.json
+++ b/testdata/data/repos/standalone/EbuildUnquotedVariablesCheck/EbuildUnquotedVariable/expected.json
@@ -1,0 +1,3 @@
+{"__class__": "EbuildUnquotedVariable", "category": "EbuildUnquotedVariablesCheck", "package": "EbuildUnquotedVariable", "version": "0", "variable": "FILESDIR", "lines": [9, 19]}
+{"__class__": "EbuildUnquotedVariable", "category": "EbuildUnquotedVariablesCheck", "package": "EbuildUnquotedVariable", "version": "0", "variable": "T", "lines": [25, 27, 41, 42]}
+{"__class__": "EbuildUnquotedVariable", "category": "EbuildUnquotedVariablesCheck", "package": "EbuildUnquotedVariable", "version": "0", "variable": "WORKDIR", "lines": [34]}

--- a/testdata/data/repos/standalone/EbuildUnquotedVariablesCheck/EbuildUnquotedVariable/fix.patch
+++ b/testdata/data/repos/standalone/EbuildUnquotedVariablesCheck/EbuildUnquotedVariable/fix.patch
@@ -1,0 +1,46 @@
+--- standalone/EbuildUnquotedVariablesCheck/EbuildUnquotedVariable/EbuildUnquotedVariable-0.ebuild	2022-05-18 20:27:34.657647175 +0200
++++ fixed/EbuildUnquotedVariablesCheck/EbuildUnquotedVariable/EbuildUnquotedVariable-0.ebuild	2022-05-18 20:50:00.271294657 +0200
+@@ -6,7 +6,7 @@
+ S=${WORKDIR}/${PV} # ok
+ 
+ PATCHES=(
+-	${FILESDIR}/foo.patch # FAIL
++	"${FILESDIR}"/foo.patch # FAIL
+ 	"${FILESDIR}"/foo.patch # ok
+ 	"${FILESDIR}/foo.patch" # ok
+ )
+@@ -16,28 +16,28 @@
+ 		:
+ 	fi
+ 
+-	if has "foo" ${FILESDIR} ; then # FAIL
++	if has "foo" "${FILESDIR}" ; then # FAIL
+ 		:
+ 	fi
+ 
+ 	local t=${T} # ok
+ 	local t=${T}/t # ok
+-	emake CC=${T}; someotherfunc ${T} # FAIL
++	emake CC="${T}"; someotherfunc "${T}" # FAIL
+ 
+-	local var=( TMP=${T} ) # FAIL
++	local var=( TMP="${T}" ) # FAIL
+ 
+ 	cat > "${T}"/somefile <<- EOF || die
+ 		PATH="${EPREFIX}${INSTALLDIR}/bin"
+ 	EOF
+ 	doenvd "${T}"/10stuffit # ok
+ 
+-	echo "InitiatorName=$(${WORKDIR}/usr/sbin/iscsi-iname)" # FAIL
++	echo "InitiatorName=$("${WORKDIR}"/usr/sbin/iscsi-iname)" # FAIL
+ 	einfo ${WORKDIR} # ok
+ 
+ 	if grep -qs '^ *sshd *:' "${WORKDIR}"/etc/hosts.{allow,deny} ; then # ok
+ 		ewarn "something something ${WORKDIR} here"
+ 	fi
+ 
+-	cat < ${T} # FAIL
+-	cat >> ${T} # FAIL
++	cat < "${T}" # FAIL
++	cat >> "${T}" # FAIL
+ }

--- a/testdata/repos/eclass/eclass/unquotedvariable.eclass
+++ b/testdata/repos/eclass/eclass/unquotedvariable.eclass
@@ -1,0 +1,19 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# @ECLASS: unquotedvariable.eclass
+# @MAINTAINER:
+# Larry the Cow <larry@gentoo.org>
+# @AUTHOR:
+# Larry the Cow <larry@gentoo.org>
+# @SUPPORTED_EAPIS: 8
+# @BLURB: Eclass that forgets to quote a variable properly
+# @DESCRIPTION:
+# A small eclass that defines a single variable, but references a variable that
+# needs to be quoted in specific contexts.
+
+# @ECLASS_VARIABLE: EBZR_STORE_DIR
+# @USER_VARIABLE
+# @DESCRIPTION:
+# The directory to store all fetched Bazaar live sources.
+: ${EBZR_STORE_DIR:=${PORTAGE_ACTUAL_DISTDIR:-${DISTDIR}}/bzr-src}

--- a/testdata/repos/standalone/EbuildUnquotedVariablesCheck/EbuildUnquotedVariable/EbuildUnquotedVariable-0.ebuild
+++ b/testdata/repos/standalone/EbuildUnquotedVariablesCheck/EbuildUnquotedVariable/EbuildUnquotedVariable-0.ebuild
@@ -1,0 +1,43 @@
+EAPI=8
+DESCRIPTION="Ebuild with variables that must be quoted"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"
+S=${WORKDIR}/${PV} # ok
+
+PATCHES=(
+	${FILESDIR}/foo.patch # FAIL
+	"${FILESDIR}"/foo.patch # ok
+	"${FILESDIR}/foo.patch" # ok
+)
+
+src_prepare() {
+	if [[ -z ${S} ]]; then  # ok
+		:
+	fi
+
+	if has "foo" ${FILESDIR} ; then # FAIL
+		:
+	fi
+
+	local t=${T} # ok
+	local t=${T}/t # ok
+	emake CC=${T}; someotherfunc ${T} # FAIL
+
+	local var=( TMP=${T} ) # FAIL
+
+	cat > "${T}"/somefile <<- EOF || die
+		PATH="${EPREFIX}${INSTALLDIR}/bin"
+	EOF
+	doenvd "${T}"/10stuffit # ok
+
+	echo "InitiatorName=$(${WORKDIR}/usr/sbin/iscsi-iname)" # FAIL
+	einfo ${WORKDIR} # ok
+
+	if grep -qs '^ *sshd *:' "${WORKDIR}"/etc/hosts.{allow,deny} ; then # ok
+		ewarn "something something ${WORKDIR} here"
+	fi
+
+	cat < ${T} # FAIL
+	cat >> ${T} # FAIL
+}


### PR DESCRIPTION
This is based on the repoman check EbuildQuote that reports instances of
some variables that should be quoted in certain contexts.

See: https://gitweb.gentoo.org/proj/portage.git/tree/repoman/lib/repoman/modules/linechecks/quotes/quotes.py?h=portage-3.0.30
Closes: https://github.com/pkgcore/pkgcheck/issues/363
Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>