### PR TITLE
network: Do not attempt to verify URL with unknown protocol

### DIFF
--- a/src/pkgcheck/checks/network.py
+++ b/src/pkgcheck/checks/network.py
@@ -208,7 +208,7 @@ class _UrlCheck(NetworkCheck):
             if url.startswith('ftp://'):
                 self._schedule_check(
                     self._ftp_check, attr, url, executor, futures, pkg=pkg)
-            else:
+            elif url.startswith(('https://', 'http://')):
                 self._schedule_check(
                     self._http_check, attr, url, executor, futures, pkg=pkg)
                 http_urls.append((attr, url))

--- a/testdata/repos/network/FetchablesUrlCheck/DeadUrl/DeadUrl-0.ebuild
+++ b/testdata/repos/network/FetchablesUrlCheck/DeadUrl/DeadUrl-0.ebuild
@@ -1,5 +1,8 @@
 DESCRIPTION="Ebuild with a dead SRC_URI"
 HOMEPAGE="https://github.com/pkgcore/pkgcheck"
-SRC_URI="https://github.com/pkgcore/pkgcheck/foo.tar.gz"
+SRC_URI="
+	https://github.com/pkgcore/pkgcheck/foo.tar.gz
+	ttps://github.com/pkgcore/pkgcheck/foo.tar.gz
+"
 LICENSE="BSD"
 SLOT="0"

--- a/testdata/repos/network/HomepageUrlCheck/DeadUrl/DeadUrl-0.ebuild
+++ b/testdata/repos/network/HomepageUrlCheck/DeadUrl/DeadUrl-0.ebuild
@@ -1,4 +1,7 @@
 DESCRIPTION="Ebuild with a dead HOMEPAGE"
-HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+HOMEPAGE="
+	https://github.com/pkgcore/pkgcheck
+	ttps://github.com/pkgcore/pkgcheck
+"
 LICENSE="BSD"
 SLOT="0"


### PR DESCRIPTION
Limit network checks to ftp, http and https URLs, in order to avoid
DeadUrl reports that are duplicate to e.g. BadHomepage.

Fixes #372