### PR TITLE
python: add PEP517 missing DISTUTILS_DEPS check

### DIFF
--- a/testdata/data/repos/python/PythonCheck/PythonMissingDeps/expected.json
+++ b/testdata/data/repos/python/PythonCheck/PythonMissingDeps/expected.json
@@ -1,1 +1,2 @@
-{"__class__": "PythonMissingDeps", "category": "PythonCheck", "package": "PythonMissingDeps", "version": "0", "dep_type": "RDEPEND"}
+{"__class__": "PythonMissingDeps", "category": "PythonCheck", "package": "PythonMissingDeps", "version": "0", "dep_type": "RDEPEND", "dep_value": "PYTHON_DEPS"}
+{"__class__": "PythonMissingDeps", "category": "PythonCheck", "package": "PythonMissingDeps", "version": "1", "dep_type": "BDEPEND", "dep_value": "DISTUTILS_DEPS"}

--- a/testdata/data/repos/python/PythonCheck/PythonMissingDeps/fix.patch
+++ b/testdata/data/repos/python/PythonCheck/PythonMissingDeps/fix.patch
@@ -7,3 +7,10 @@ diff -Naur python/PythonCheck/PythonMissingDeps/PythonMissingDeps-0.ebuild fixed
  REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 +
 +RDEPEND="${PYTHON_DEPS}"
+--- python/PythonCheck/PythonMissingDeps/PythonMissingDeps-1.ebuild
++++ fixed/PythonCheck/PythonMissingDeps/PythonMissingDeps-1.ebuild
+@@ -15,3 +15,4 @@
+ IUSE="python"
+ 
+ RDEPEND="python? ( ${PYTHON_DEPS} )"
++BDEPEND="python? ( ${DISTUTILS_DEPS} )"

--- a/testdata/repos/python/PythonCheck/PythonMissingDeps/PythonMissingDeps-1.ebuild
+++ b/testdata/repos/python/PythonCheck/PythonMissingDeps/PythonMissingDeps-1.ebuild
@@ -1,0 +1,17 @@
+EAPI=8
+
+DISTUTILS_OPTIONAL=1
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_10 )
+
+inherit distutils-r1
+
+DESCRIPTION="Ebuild with missing distutils-r1 PEP517 deps"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+LICENSE="BSD"
+SLOT="0"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+
+IUSE="python"
+
+RDEPEND="python? ( ${PYTHON_DEPS} )"

--- a/testdata/repos/python/PythonCheck/PythonMissingDeps/PythonMissingDeps-2.ebuild
+++ b/testdata/repos/python/PythonCheck/PythonMissingDeps/PythonMissingDeps-2.ebuild
@@ -1,0 +1,17 @@
+EAPI=8
+
+DISTUTILS_OPTIONAL=1
+DISTUTILS_USE_PEP517=no
+PYTHON_COMPAT=( python3_10 )
+
+inherit distutils-r1
+
+DESCRIPTION="Ebuild with correct distutils-r1 PEP517 deps (PEP517=no)"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+LICENSE="BSD"
+SLOT="0"
+
+IUSE="python"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+
+RDEPEND="python? ( ${PYTHON_DEPS} )"

--- a/testdata/repos/python/PythonCheck/PythonMissingDeps/metadata.xml
+++ b/testdata/repos/python/PythonCheck/PythonMissingDeps/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+        <use>
+                <flag name="python">enable Python support</flag>
+        </use>
+</pkgmetadata>

--- a/testdata/repos/python/eclass/distutils-r1.eclass
+++ b/testdata/repos/python/eclass/distutils-r1.eclass
@@ -1,0 +1,60 @@
+# @ECLASS: distutils-r1.eclass
+# @MAINTAINER:
+# Python team <python@gentoo.org>
+# @AUTHOR:
+# Author: Michał Górny <mgorny@gentoo.org>
+# Based on the work of: Krzysztof Pawlik <nelchael@gentoo.org>
+# @SUPPORTED_EAPIS: 6 7 8
+# @PROVIDES: python-r1 python-single-r1
+
+# @ECLASS_VARIABLE: DISTUTILS_OPTIONAL
+# @DEFAULT_UNSET
+# @DESCRIPTION:
+
+# @ECLASS_VARIABLE: DISTUTILS_DEPS
+# @DESCRIPTION:
+# See the variable docs in the related gentoo repo eclass.
+
+if [[ ! ${DISTUTILS_SINGLE_IMPL} ]]; then
+	inherit python-r1
+else
+	inherit python-single-r1
+fi
+
+_distutils_set_globals() {
+	local rdep bdep
+	if [[ ${DISTUTILS_USE_PEP517} ]]; then
+		if [[ ${DISTUTILS_USE_SETUPTOOLS} ]]; then
+			die "DISTUTILS_USE_SETUPTOOLS is not used in PEP517 mode"
+		fi
+
+		bdep='
+			>=dev-python/gpep517-8[${PYTHON_USEDEP}]
+		'
+    fi
+
+	if [[ ! ${DISTUTILS_SINGLE_IMPL} ]]; then
+		bdep=${bdep//\$\{PYTHON_USEDEP\}/${PYTHON_USEDEP}}
+		rdep=${rdep//\$\{PYTHON_USEDEP\}/${PYTHON_USEDEP}}
+	else
+		[[ -n ${bdep} ]] && bdep="$(python_gen_cond_dep "${bdep}")"
+		[[ -n ${rdep} ]] && rdep="$(python_gen_cond_dep "${rdep}")"
+	fi
+
+	if [[ ${DISTUTILS_USE_PEP517} ]]; then
+        DISTUTILS_DEPS=${bdep}
+        readonly DISTUTILS_DEPS
+	fi
+
+	if [[ ! ${DISTUTILS_OPTIONAL} ]]; then
+		RDEPEND="${PYTHON_DEPS} ${rdep}"
+		if [[ ${EAPI} != 6 ]]; then
+			BDEPEND="${PYTHON_DEPS} ${bdep}"
+		else
+			DEPEND="${PYTHON_DEPS} ${bdep}"
+		fi
+		REQUIRED_USE=${PYTHON_REQUIRED_USE}
+	fi
+}
+_distutils_set_globals
+unset -f _distutils_set_globals


### PR DESCRIPTION
```
    python: add PEP517 missing DISTUTILS_DEPS check

    Check for whether BDEPEND="${DISTUTILS_DEPS}" is missing
    in PEP517 ebuilds with DISTUTILS_OPTIONAL set.

    Implementation notes:
    * Ended up not merging this w/ existing PythonCheck because of how
      awkward it made testing and the edge cases that ended up being added.

    * Wanted to fold this into PythonCheck's check_depend(), but
      this doesn't fit super well, given we need to:

      1. check for DISTUTILS_USE_PEP517 != no;
      2. check for DISTUTILS_OPTIONAL;
      3. check for ${DISTUTILS_DEPS} rather than a specific
         interpreter (don't want to get into copying eclass logic
         for specific packages needed per backend).

      For the last point (3), we could actually just look for
      dev-python/gpep517, which might be good enough.

    Fixes: https://github.com/pkgcore/pkgcheck#388
    Signed-off-by: Sam James <sam@gentoo.org>
```