### PR TITLE
network: Fix metadata.xml results when old version is present

### DIFF
--- a/src/pkgcheck/checks/network.py
+++ b/src/pkgcheck/checks/network.py
@@ -296,4 +296,4 @@ class MetadataUrlCheck(_UrlCheck):
                         yield f'metadata.xml: {element}', url
 
     def schedule(self, pkgs, *args, **kwargs):
-        super().schedule(pkgs[0], *args, **kwargs)
+        super().schedule(pkgs[-1], *args, **kwargs)


### PR DESCRIPTION
Apply metadata.xml URL check results to the newest package version
rather than the oldest, in order to fix displaying them when multiple
package versions are available.  Since the result objects are subclasses
of FilteredVersionResult, they are filtered out when they do not apply
to the newest version.

Closes: https://github.com/pkgcore/pkgcheck/issues/385