### PR TITLE
network: Limit checks to newest versions in slot (correctly)

### DIFF
--- a/src/pkgcheck/checks/network.py
+++ b/src/pkgcheck/checks/network.py
@@ -12,7 +12,7 @@ from .. import addons, results, sources
 from . import NetworkCheck
 
 
-class _UrlResult(results.FilteredVersionResult, results.Warning):
+class _UrlResult(results.VersionResult, results.Warning):
     """Generic result for a URL with some type of failed status."""
 
     def __init__(self, attr, url, message, **kwargs):
@@ -42,7 +42,7 @@ class SSLCertificateError(_UrlResult):
         return f'{self.attr}: SSL cert error: {self.message}: {self.url}'
 
 
-class _UpdatedUrlResult(results.FilteredVersionResult, results.Warning):
+class _UpdatedUrlResult(results.VersionResult, results.Warning):
     """Generic result for a URL that should be updated to an alternative."""
 
     message = None

--- a/src/pkgcheck/checks/network.py
+++ b/src/pkgcheck/checks/network.py
@@ -98,6 +98,8 @@ class RequestError(_RequestException):
 class _UrlCheck(NetworkCheck):
     """Generic URL verification check requiring network support."""
 
+    _source = sources.LatestVersionRepoSource
+
     known_results = frozenset([
         DeadUrl, RedirectedUrl, HttpsUrlAvailable, SSLCertificateError,
     ])

--- a/src/pkgcheck/objects.py
+++ b/src/pkgcheck/objects.py
@@ -170,9 +170,7 @@ class _KeywordsLazyDict(_LazyDict):
     @klass.jit_attr
     def filter(self):
         """Mapping of default result filters."""
-        from . import results
-        return ImmutableDict({
-            v: 'latest' for v in self.select(results.FilteredVersionResult).values()})
+        return ImmutableDict()
 
 
 class _ChecksLazyDict(_LazyDict):

--- a/src/pkgcheck/results.py
+++ b/src/pkgcheck/results.py
@@ -254,10 +254,6 @@ class LineResult(VersionResult):
         return super().__lt__(other, cmp=cmp)
 
 
-class FilteredVersionResult(VersionResult):
-    """Result that will be optionally filtered for old packages by default."""
-
-
 class _LogResult(Result):
     """Message caught from a logger instance."""
 


### PR DESCRIPTION
Replace the resulting filter in network checks with source filtering. This has the advantage that the checks are actually done only for the interesting versions, rather than being done (and therefore the requests sent) for old versions, and then discarded. This uses a new source class that is roughly based on newest version filtering but actually works.