### PR TITLE
GitPkgCommitsCheck: fix files check

### DIFF
--- a/src/pkgcheck/checks/git.py
+++ b/src/pkgcheck/checks/git.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import shutil
 import subprocess
 import tarfile
 from collections import defaultdict
@@ -187,6 +188,8 @@ class _RemovalRepo(UnconfiguredTree):
         os.makedirs(pjoin(repo_dir, 'profiles'))
         with open(pjoin(repo_dir, 'profiles', 'repo_name'), 'w') as f:
             f.write('old-repo\n')
+        if os.path.exists(pjoin(repo_dir, 'eclass')):
+            shutil.copytree(pjoin(repo.location, 'eclass'), pjoin(repo_dir, 'eclass'), dirs_exist_ok=True)
         super().__init__(repo_dir)
 
     def __call__(self, pkgs):


### PR DESCRIPTION
When using `_RemovalRepo` for previous git state repo, it uses
`UnconfiguredTree::_pkg_filter` as default pkg_filter. During the
check for various bad file, it tries to parse the ebuild, which in
turn tries to check the usage around inherited eclasses - which
doesn't exist in this repo.

In theory, the setting of masters repo as the original one should
suffice, but it doesn't in practice. For now, let's copy the eclass
content so at least this very important check is done!