### PR TITLE
contrib/emacs: add flycheck-pkgcheck.el - Flycheck checker for ebuilds

### DIFF
--- a/contrib/emacs/flycheck-pkgcheck.el
+++ b/contrib/emacs/flycheck-pkgcheck.el
@@ -1,0 +1,81 @@
+;;; flycheck-pkgcheck.el --- Flycheck checker for ebuilds -*- lexical-binding: t -*-
+
+
+;; Copyright (c) 2006-2021, pkgcheck contributors
+
+;; Authors: Maciej Barć <xgqt@gentoo.org>
+;; Keywords: convenience processes tools
+;; Homepage: https://pkgcore.github.io/pkgcheck/
+;; SPDX-License-Identifier: BSD-3-Clause
+;; Package-Requires: ((emacs "24.1") (flycheck "32"))
+;; Version: 1.0.0
+
+
+
+;;; Commentary:
+
+
+;; Flycheck checker for ebuilds using the "pkgcheck" utility.
+
+;; This checker uses a reported made exclusively for it - FlycheckReporter.
+
+;; In addition to "Package-Requires" also ebuild-mode is required for hooks.
+
+
+
+;;; Code:
+
+
+(require 'flycheck)
+
+
+(defgroup flycheck-pkgcheck nil
+  "Flycheck checker for ebuilds."
+  :group 'external
+  :group 'flycheck)
+
+
+(defcustom flycheck-pkgcheck-enable t
+  "Whether to enable flycheck checker for ebuilds."
+  :type 'boolean
+  :group 'flycheck-pkgcheck)
+
+
+(flycheck-define-checker pkgcheck
+  "A checker for ebuild files."
+  :modes ebuild-mode
+  :predicate (lambda () (buffer-file-name))
+  :command ("pkgcheck"
+            "scan"
+            "--exit="
+            "--reporter=FlycheckReporter"
+            "--scopes=-git"
+            "--verbose"
+            (eval (buffer-file-name)))
+  :error-patterns
+  ((info
+    line-start (file-name) ":" line ":" "info" ":" (message) line-end)
+   (info
+    line-start (file-name) ":" line ":" "style" ":" (message) line-end)
+   (warning
+    line-start (file-name) ":" line ":" "warning" ":" (message) line-end)
+   (error
+    line-start (file-name) ":" line ":" "error" ":" (message) line-end)))
+
+
+;;;###autoload
+(defun flycheck-pkgcheck-setup ()
+  "Flycheck pkgcheck setup."
+  (interactive)
+  (when flycheck-pkgcheck-enable
+    (add-to-list 'flycheck-checkers 'pkgcheck t)))
+
+;;;###autoload
+(add-hook 'ebuild-mode-hook 'flycheck-pkgcheck-setup)
+
+
+(provide 'flycheck-pkgcheck)
+
+
+
+;;; flycheck-pkgcheck.el ends here

--- a/src/pkgcheck/reporters.py
+++ b/src/pkgcheck/reporters.py
@@ -303,3 +303,21 @@ class JsonStream(Reporter):
         while True:
             result = (yield)
             self.out.write(json.dumps(result, default=self.to_json))
+
+
+class FlycheckReporter(Reporter):
+    """Simple line reporter done for easier integration with flycheck [#]_ .
+
+    .. [#] https://github.com/flycheck/flycheck
+    """
+
+    priority = -1001
+
+    @coroutine
+    def _process_report(self):
+        while True:
+            result = (yield)
+            file = f'{getattr(result, "package", "")}-{getattr(result, "version", "")}.ebuild'
+            lineno = getattr(result, "lineno", 0)
+            message = f'{getattr(result, "name")}: {getattr(result, "desc")}'
+            self.out.write(f'{file}:{lineno}:{getattr(result, "level")}:{message}')


### PR DESCRIPTION
Bug: https://github.com/pkgcore/pkgcheck/issues/417

Signed-off-by: Maciej Barć <xgqt@gentoo.org>