### PR TITLE
UncheckableDep: add testcase

### DIFF
--- a/testdata/data/repos/visibility/VisibilityCheck/UncheckableDep/expected.json
+++ b/testdata/data/repos/visibility/VisibilityCheck/UncheckableDep/expected.json
@@ -1,0 +1,1 @@
+{"__class__": "UncheckableDep", "category": "UncheckableDep", "package": "UncheckableDep", "version": "0", "attr": "rdepend"}

--- a/testdata/data/repos/visibility/VisibilityCheck/UncheckableDep/fix.patch
+++ b/testdata/data/repos/visibility/VisibilityCheck/UncheckableDep/fix.patch
@@ -1,0 +1,14 @@
+--- standalone/UncheckableDep/UncheckableDep/UncheckableDep-0.ebuild    2022-08-07 03:50:01.594610569 +0100
++++ fixed/UncheckableDep/UncheckableDep/UncheckableDep-0.ebuild 2022-08-07 03:50:03.207956684 +0100
+@@ -15,7 +15,10 @@
+ LLVM_DEPEND="|| ( "
+ for _s in 13 14 15; do
+ 	LLVM_DEPEND+=" ( "
+-	LLVM_DEPEND+=" stub/stable:${_s}[${LLVM_TARGET_USEDEPS// /,}]"
++	for _x in ${ALL_LLVM_TARGETS[@]}; do
++	        LLVM_DEPEND+="
++			${_x}? ( stub/stable:${_s}[${_x}(-)] )"
++	done
+ 	LLVM_DEPEND+=" )"
+ done
+ LLVM_DEPEND+=" ) "

--- a/testdata/repos/visibility/UncheckableDep/UncheckableDep/UncheckableDep-0.ebuild
+++ b/testdata/repos/visibility/UncheckableDep/UncheckableDep/UncheckableDep-0.ebuild
@@ -1,0 +1,22 @@
+EAPI=7
+DESCRIPTION="Ebuild with uncheckable large amount of USE deps"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"
+
+# This example is pulled out of dev-lang/rust:
+# https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-lang/rust/rust-1.62.1.ebuild?id=60de1a24bbd551cb852f54ebf2b1aa5620c2aa2c#n55
+ALL_LLVM_TARGETS=( AArch64 AMDGPU ARM AVR BPF Hexagon Lanai Mips MSP430
+	NVPTX PowerPC RISCV Sparc SystemZ WebAssembly X86 XCore )
+ALL_LLVM_TARGETS=( "${ALL_LLVM_TARGETS[@]/#/llvm_targets_}" )
+LLVM_TARGET_USEDEPS=${ALL_LLVM_TARGETS[@]/%/(-)?}
+
+IUSE+="${ALL_LLVM_TARGETS[@]#-}"
+LLVM_DEPEND="|| ( "
+for _s in 13 14 15; do
+	LLVM_DEPEND+=" ( "
+	LLVM_DEPEND+=" stub/stable:${_s}[${LLVM_TARGET_USEDEPS// /,}]"
+	LLVM_DEPEND+=" )"
+done
+LLVM_DEPEND+=" ) "
+RDEPEND="${LLVM_DEPEND}"


### PR DESCRIPTION
UncheckableDep: add testcase

Adapted from dev-lang/rust. We didn't have coverage
over this result at all, so throw it in.

More coverage is always good, but in particular,
we want to know if we stop immediately
aborting on complicated deps. It could be a regression
(we parse for ages and give up -> hang).

Signed-off-by: Sam James <sam@gentoo.org>
