### PR TITLE
StableRequestCheck: Add stabletime config option

### DIFF
--- a/src/pkgcheck/checks/stablereq.py
+++ b/src/pkgcheck/checks/stablereq.py
@@ -70,7 +70,7 @@ class StableRequestCheck(GentooRepoCheck):
 
                     added = datetime.fromtimestamp(match.time)
                     days_old = (self.today - added).days
-                    if days_old >= 30:
+                    if days_old >= self.options.stable_time:
                         pkg_stable_keywords = {x.lstrip('~') for x in pkg.keywords}
                         if stable_slot_keywords:
                             keywords = stable_slot_keywords.intersection(pkg_stable_keywords)

--- a/src/pkgcheck/scripts/pkgcheck_scan.py
+++ b/src/pkgcheck/scripts/pkgcheck_scan.py
@@ -190,6 +190,14 @@ check_options.add_argument(
         Use ``pkgcheck show --keywords`` to see available options.
     """)
 
+check_options.add_argument(
+    '--stabletime', metavar='DAYS', dest='stable_time', default=30,
+    type=arghparse.positive_int, help='set number of days before stabilisation',
+    docs="""
+        An integer number of days before a package version is flagged by
+        StableRequestCheck. Defaults to 30 days.
+    """)
+
 scan.plugin = scan.add_argument_group('plugin options')
 
 


### PR DESCRIPTION
This commit adds an option allows the user to specify the time before a version is flagged by StableRequestCheck. The primary use case for this is in overlays where the stabilisation policy may be different from ::gentoo.

I deliberately did not add a short option for `--stabletime` because there are a limited number of valid single-letter options, and I didn't think that this case warranted using one. If maintainers think it's a good idea to have one, I'd be happy to add it in.