### PR TITLE
MissingInherits: fix false positives with unset

### DIFF
--- a/src/pkgcheck/checks/codingstyle.py
+++ b/src/pkgcheck/checks/codingstyle.py
@@ -709,6 +709,8 @@ class InheritsCheck(Check):
         # match captured variables with eclasses
         for node, _ in bash.var_query.captures(pkg.tree.root_node):
             name = pkg.node_str(node)
+            if node.parent.type == 'unset_command':
+                continue
             if name not in self.eapi_vars[pkg.eapi] | assigned_vars.keys():
                 lineno, colno = node.start_point
                 if eclass := self.get_eclass(name, pkg):

--- a/testdata/repos/eclass/InheritsCheck/MissingInherits/MissingInherits-0.ebuild
+++ b/testdata/repos/eclass/InheritsCheck/MissingInherits/MissingInherits-0.ebuild
@@ -7,4 +7,5 @@ LICENSE="BSD"
 
 src_prepare() {
 	inherit_public_func
+	unset EBUILD_TEST
 }


### PR DESCRIPTION
tree-sitter-bash uses type variable_name for the variable names when
unset is used. Add a special case when a variable_name is detected whose
parent is unset_command.

Resolves: https://github.com/pkgcore/pkgcheck/issues/353