### PR TITLE
BadCommitSummary: version check should be ignored for acct-* packages

### DIFF
--- a/src/pkgcheck/checks/git.py
+++ b/src/pkgcheck/checks/git.py
@@ -495,6 +495,11 @@ class GitCommitMessageCheck(GentooRepoCheck, GitCommitsCheck):
     _commit_footer_regex = re.compile(r'^(?P<tag>[a-zA-Z0-9_-]+): (?P<value>.*)$')
     _git_cat_file_regex = re.compile(r'^(?P<object>.+?) (?P<status>.+)$')
 
+    # categories exception for rule of having package version in summary
+    skipped_categories = frozenset({
+        'acct-group', 'acct-user', 'virtual',
+    })
+
     def __init__(self, *args):
         super().__init__(*args)
         # mapping of required tags to forcibly run verifications methods
@@ -577,7 +582,7 @@ class GitCommitMessageCheck(GentooRepoCheck, GitCommitsCheck):
                     error = f'summary missing {atom.key!r} package prefix'
                     yield BadCommitSummary(error, summary, commit=commit)
                 # check for version in summary for singular, non-revision bumps
-                if len(commit.pkgs['A']) == 1:
+                if len(commit.pkgs['A']) == 1 and category not in self.skipped_categories:
                     atom = next(iter(commit.pkgs['A']))
                     if not atom.revision and not re.match(rf'^.+\bv?{re.escape(atom.version)}\b.*$', summary):
                         error = f'summary missing package version {atom.version!r}'

--- a/tests/checks/test_git.py
+++ b/tests/checks/test_git.py
@@ -283,6 +283,18 @@ class TestGitCommitMessageRepoCheck(ReportTestCase):
         self.init_check()
         self.assertNoReport(self.check, self.source)
 
+        # special categories that allow not having version in new package summary
+        self.child_repo.create_ebuild('acct-user/pkgcheck-1')
+        self.child_git_repo.add_all('acct-user/pkgcheck: add user for pkgcheck', signoff=True)
+        self.init_check()
+        self.assertNoReport(self.check, self.source)
+
+        # special categories that allow not having version in bump version summary
+        self.child_repo.create_ebuild('acct-user/pkgcheck-2')
+        self.child_git_repo.add_all('acct-user/pkgcheck: bump user for pkgcheck', signoff=True)
+        self.init_check()
+        self.assertNoReport(self.check, self.source)
+
         # poorly prefixed commit summary
         self.child_repo.create_ebuild('cat/pkg-4')
         self.child_git_repo.add_all('version bump to 4', signoff=True)


### PR DESCRIPTION
When doing the checks for commit summary, add an exception to the rule
for acct-* packages, so the version added isn't a must for them.

Resolves: https://github.com/pkgcore/pkgcheck/issues/433