### PR TITLE
ReservedNameCheck: update rules for usage of reserved

### DIFF
--- a/testdata/data/repos/eclass/EclassReservedCheck/EclassReservedName/expected.json
+++ b/testdata/data/repos/eclass/EclassReservedCheck/EclassReservedName/expected.json
@@ -1,2 +1,5 @@
 {"__class__": "EclassReservedName", "eclass": "reserved", "used_name": "prepare_locale", "used_type": "function", "reserved_word": "prep", "reserved_type": "prefix"}
+{"__class__": "EclassReservedName", "eclass": "reserved", "used_name": "DYNAMIC_DEPS", "used_type": "variable", "reserved_word": "dyn", "reserved_type": "prefix"}
+{"__class__": "EclassReservedName", "eclass": "reserved", "used_name": "EBUILD", "used_type": "variable", "reserved_word": "ebuild", "reserved_type": "substring"}
 {"__class__": "EclassReservedName", "eclass": "reserved", "used_name": "EBUILD_TEST", "used_type": "variable", "reserved_word": "ebuild", "reserved_type": "substring"}
+{"__class__": "EclassReservedName", "eclass": "reserved", "used_name": "prepared", "used_type": "variable", "reserved_word": "prep", "reserved_type": "prefix"}

--- a/testdata/repos/eclass/eclass/reserved.eclass
+++ b/testdata/repos/eclass/eclass/reserved.eclass
@@ -11,8 +11,10 @@
 # Public stub function.
 prepare_locale() {
 	local DYNAMIC_DEPS
-	local prepered
+	local prepared
 	export EBUILD_DEATH_HOOKS="die"
+	echo "${EBUILD}" # This is wrong
+	echo "${EBUILD_PHASE}" # This is fine
 }
 
 # @ECLASS_VARIABLE: EBUILD_TEST

--- a/tests/scripts/test_pkgcheck_scan.py
+++ b/tests/scripts/test_pkgcheck_scan.py
@@ -527,7 +527,7 @@ class TestPkgcheckScan:
 
     @pytest.mark.parametrize('repo', repos)
     def test_scan_repo_verbose(self, repo, tmp_path):
-        """Scan a target repo in verbose mode, saving results for verfication."""
+        """Scan a target repo in verbose mode, saving results for verification."""
         return self.test_scan_repo(repo, tmp_path, verbosity=1)
 
     def _get_results(self, path):


### PR DESCRIPTION
Using reserved variable names, and not only defining, is prohibited.
Also add new exceptions to the list of reserved names.

There was no need to update the implementation for functions calls, as the current query catches them.