### PR TITLE
UnquotedVariablesCheck: add `:` to message_commands

### DIFF
--- a/src/pkgcheck/checks/codingstyle.py
+++ b/src/pkgcheck/checks/codingstyle.py
@@ -945,7 +945,7 @@ class _UnquotedVariablesCheck(Check):
     """Scan files for variables that should be quoted like D, FILESDIR, etc."""
 
     message_commands = frozenset({
-        "die", "echo", "eerror", "einfo", "elog", "eqawarn", "ewarn"
+        "die", "echo", "eerror", "einfo", "elog", "eqawarn", "ewarn", ":"
     })
     var_names = frozenset({
         "D", "DISTDIR", "FILESDIR", "S", "T", "ROOT", "BROOT", "WORKDIR", "ED",

--- a/testdata/data/repos/eclass/EclassUnquotedVariablesCheck/EclassUnquotedVariable/expected.json
+++ b/testdata/data/repos/eclass/EclassUnquotedVariablesCheck/EclassUnquotedVariable/expected.json
@@ -1,1 +1,1 @@
-{"__class__": "EclassUnquotedVariable", "eclass": "unquotedvariable", "variable": "DISTDIR", "lines": [19]}
+{"__class__": "EclassUnquotedVariable", "eclass": "unquotedvariable", "variable": "D", "lines": [26]}

--- a/testdata/repos/eclass/eclass/unquotedvariable.eclass
+++ b/testdata/repos/eclass/eclass/unquotedvariable.eclass
@@ -15,5 +15,13 @@
 # @ECLASS_VARIABLE: EBZR_STORE_DIR
 # @USER_VARIABLE
 # @DESCRIPTION:
-# The directory to store all fetched Bazaar live sources.
+# Some text
 : ${EBZR_STORE_DIR:=${PORTAGE_ACTUAL_DISTDIR:-${DISTDIR}}/bzr-src}
+
+# @FUNCTION: webapp_configfile
+# @USAGE: <file> [more files ...]
+# @DESCRIPTION:
+# Some text
+webapp_configfile() {
+	echo "${my_file}" >> ${D}/${WA_CONFIGLIST}
+}


### PR DESCRIPTION
The `:` command is used for various setting of variables, while not using the value. As a result, `: ${VAR:=${D}}` is fine, as it won't use spaced variable, but `foo ${VAR:=${D}}` will use the unquoted result of D.