### PR TITLE
GitPkgCommitsCheck: add prefix and suffix for tmpdir

### DIFF
--- a/src/pkgcheck/checks/git.py
+++ b/src/pkgcheck/checks/git.py
@@ -176,7 +176,7 @@ class _RemovalRepo(UnconfiguredTree):
 
     def __init__(self, repo):
         self.__parent_repo = repo
-        self.__tmpdir = TemporaryDirectory()
+        self.__tmpdir = TemporaryDirectory(prefix='tmp-pkgcheck-', suffix='.repo')
         self.__created = False
         repo_dir = self.__tmpdir.name
 


### PR DESCRIPTION
Sadly, I still have no facility to cleanup on exit the tmpdir, so for now add prefix and suffix to the dirs, to make it clear to users who spams their tmpdir.