### PR TITLE
FlycheckReporter: split multiple line results

### DIFF
--- a/src/pkgcheck/checks/metadata_xml.py
+++ b/src/pkgcheck/checks/metadata_xml.py
@@ -206,22 +206,19 @@ class CatMetadataXmlInvalidCatRef(_MetadataXmlInvalidCatRef, results.CategoryRes
     """Invalid category reference in category metadata.xml."""
 
 
-class _MetadataXmlIndentation(results.Style):
+class _MetadataXmlIndentation(results.BaseLinesResult, results.Style):
     """Inconsistent indentation in metadata.xml file.
 
     Either all tabs or all spaces should be used, not a mixture of both.
     """
 
-    def __init__(self, filename, lines, **kwargs):
+    def __init__(self, filename, **kwargs):
         super().__init__(**kwargs)
         self.filename = filename
-        self.lines = tuple(lines)
 
     @property
     def desc(self):
-        s = pluralism(self.lines)
-        lines = ', '.join(self.lines)
-        return f'{self.filename}: metadata.xml has inconsistent indentation on line{s}: {lines}'
+        return f'{self.filename}: metadata.xml has inconsistent indentation {self.lines_str}'
 
 
 class CatMetadataXmlIndentation(_MetadataXmlIndentation, results.CategoryResult):
@@ -364,7 +361,7 @@ class _XmlBaseCheck(Check):
                         else:
                             indents.add(lineno)
         if indents:
-            yield self.indent_error(os.path.basename(loc), map(str, sorted(indents)), pkg=pkg)
+            yield self.indent_error(os.path.basename(loc), lines=map(str, sorted(indents)), pkg=pkg)
 
     @staticmethod
     def _format_lxml_errors(error_log):

--- a/src/pkgcheck/checks/python.py
+++ b/src/pkgcheck/checks/python.py
@@ -473,7 +473,7 @@ class PythonGHDistfileSuffixCheck(Check):
                     break
 
 
-class PythonHasVersionUsage(results.VersionResult, results.Style):
+class PythonHasVersionUsage(results.LinesResult, results.Style):
     """Package uses has_version inside ``python_check_deps``.
 
     Ebuilds which declare the ``python_check_deps`` function (which tests
@@ -484,15 +484,9 @@ class PythonHasVersionUsage(results.VersionResult, results.Style):
     .. [#] https://projects.gentoo.org/python/guide/any.html#dependencies
     """
 
-    def __init__(self, lines, **kwargs):
-        super().__init__(**kwargs)
-        self.lines = tuple(lines)
-
     @property
     def desc(self):
-        s = pluralism(self.lines)
-        lines = ', '.join(map(str, self.lines))
-        return f'usage of has_version on line{s}: {lines}, replace with python_has_version'
+        return f'usage of has_version {self.lines_str}, replace with python_has_version'
 
 
 class PythonHasVersionMissingPythonUseDep(results.LineResult, results.Error):

--- a/src/pkgcheck/checks/whitespace.py
+++ b/src/pkgcheck/checks/whitespace.py
@@ -3,23 +3,12 @@
 import re
 from typing import NamedTuple
 
-from snakeoil.strings import pluralism
-
 from .. import results, sources
 from . import Check
 
 
-class _Whitespace(results.VersionResult, results.Style):
-
-    def __init__(self, lines, **kwargs):
-        super().__init__(**kwargs)
-        self.lines = tuple(lines)
-
-    @property
-    def lines_str(self):
-        s = pluralism(self.lines)
-        lines = ', '.join(map(str, self.lines))
-        return f'line{s}: {lines}'
+class _Whitespace(results.LinesResult, results.Style):
+    ...
 
 
 class WhitespaceFound(_Whitespace):
@@ -47,7 +36,7 @@ class DoubleEmptyLine(_Whitespace):
 
     @property
     def desc(self):
-        return f"ebuild has unneeded empty {self.lines_str}"
+        return f"ebuild has unneeded empty line on {self.lines_str}"
 
 
 class TrailingEmptyLine(results.VersionResult, results.Style):

--- a/src/pkgcheck/reporters.py
+++ b/src/pkgcheck/reporters.py
@@ -9,7 +9,7 @@ from xml.sax.saxutils import escape as xml_escape
 from snakeoil.decorators import coroutine
 
 from . import base
-from .results import InvalidResult, Result
+from .results import BaseLinesResult, InvalidResult, Result
 
 
 class Reporter:
@@ -318,6 +318,11 @@ class FlycheckReporter(Reporter):
         while True:
             result = (yield)
             file = f'{getattr(result, "package", "")}-{getattr(result, "version", "")}.ebuild'
-            lineno = getattr(result, "lineno", 0)
             message = f'{getattr(result, "name")}: {getattr(result, "desc")}'
-            self.out.write(f'{file}:{lineno}:{getattr(result, "level")}:{message}')
+            if isinstance(result, BaseLinesResult):
+                message = message.replace(result.lines_str, '').strip()
+                for lineno in result.lines:
+                    self.out.write(f'{file}:{lineno}:{getattr(result, "level")}:{message}')
+            else:
+                lineno = getattr(result, "lineno", 0)
+                self.out.write(f'{file}:{lineno}:{getattr(result, "level")}:{message}')

--- a/src/pkgcheck/results.py
+++ b/src/pkgcheck/results.py
@@ -4,6 +4,7 @@ from functools import total_ordering
 
 from pkgcore.ebuild import cpv
 from snakeoil import klass
+from snakeoil.strings import pluralism
 
 from . import base
 from .packages import FilteredPkg, RawCPV
@@ -78,6 +79,20 @@ class Result:
 
 class AliasResult(Result):
     """Classes directly inheriting this class can be targeted as scannable keywords."""
+
+
+class BaseLinesResult:
+    """Base class for results of multiples lines."""
+
+    def __init__(self, lines, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.lines = tuple(lines)
+
+    @property
+    def lines_str(self):
+        s = pluralism(self.lines)
+        lines = ', '.join(map(str, self.lines))
+        return f'on line{s}: {lines}'
 
 
 class Error(Result):
@@ -228,6 +243,10 @@ class VersionResult(PackageResult):
         except AttributeError:
             pass
         return super().__lt__(other)
+
+
+class LinesResult(BaseLinesResult, VersionResult):
+    """Result related to multiples lines of an ebuild."""
 
 
 class LineResult(VersionResult):


### PR DESCRIPTION
All multiple lines results are split into separate output lines, making it much nicer to use when using flycheck. It also does best effort to clean the lines list from `desc` so the output is shorter and cleaner.

@xgqt can you please review how it looks for you now?

Resolves: https://github.com/pkgcore/pkgcheck/issues/442