### PR TITLE
ci: split release workflow into parallel jobs

### DIFF
--- a/.github/workflows/manylinux.sh
+++ b/.github/workflows/manylinux.sh
@@ -2,16 +2,20 @@
 # Mangle the manylinux docker image to successfully build and test wheels.
 
 set -e
+set +x
 
 # install git
 if type -P apk; then
-    apk add --no-cache git bash
+    apk add --no-cache git bash py3-lxml
+elif type -P yum; then
+    yum update -y
+    yum install -y libxslt-devel libxml2-devel python-devel
 else
     apt-get update
-    apt-get install -y git
+    apt-get install -y git libxml2-dev libxslt-dev python-dev
 fi
 
 # download static build of recent bash release
-URL="https://github.com/robxu9/bash-static/releases/download/5.1.008-1.2.2/bash-linux-x86_64"
+URL="https://github.com/robxu9/bash-static/releases/download/5.1.016-1.2.3/bash-linux-${1:-x86_64}"
 curl -L "$URL" > /usr/local/bin/bash
 chmod +x /usr/local/bin/bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
     tags: [v*]
 
 jobs:
-  build-and-deploy:
+  build-sdist:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
@@ -16,8 +16,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
-        cache: 'pip'
-        cache-dependency-path: requirements/*.txt
 
     - name: Install dependencies
       run: |
@@ -38,48 +36,65 @@ jobs:
         # run in-place build so wheel deps use release versions
         python setup.py build_py -i
 
+    - name: Output dist file info
+      run: |
+        tar -ztf dist/*.tar.gz | sort
+
+    - name: Upload sdist artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: dist
+        path: dist/*.tar.gz
+
+
+  build-wheel:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pyver: [cp38, cp39, cp310, cp311]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
     - name: Build wheels
-      uses: joerick/cibuildwheel@v2.8.1
+      uses: joerick/cibuildwheel@v2.10.0
       with:
         output-dir: dist
       env:
-        CIBW_BUILD: cp38-* cp39-* cp310-* cp311-*
+        CIBW_BUILD: ${{matrix.pyver}}-*
         CIBW_ARCHS_LINUX: x86_64
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
-        CIBW_PRERELEASE_PYTHONS: True
         CIBW_BEFORE_BUILD: pip install -r {project}/requirements/dist.txt && {project}/.github/workflows/manylinux.sh
         CIBW_BEFORE_TEST: pip install -r {project}/requirements/test.txt
         CIBW_ENVIRONMENT: PY_COLORS=1
         CIBW_TEST_COMMAND: pytest -v {project}/tests
 
-    - name: Output dist file info
-      run: |
-        sha512sum dist/*
-        tar -ztf dist/*.tar.gz | sort
-
-    - uses: actions/upload-artifact@v3
+    - name: Upload wheel artifacts
+      uses: actions/upload-artifact@v3
       with:
-        name: results
-        path: dist/*
+        name: dist
+        path: dist/*.whl
 
-    - name: Install twine and check files
-      run: |
-        pip install twine wheel-inspect
-        twine check dist/*
-        wheel2json dist/*.whl
 
-    - name: Upload to PyPI
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-      # only upload files for tagged releases
-      if: startsWith(github.ref, 'refs/tags/')
-      run: |
-        twine upload dist/*
+  deploy:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: ["build-sdist", "build-wheel"]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: dist
+        path: dist
+
+    - name: Publish a Python distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        print_hash: true
 
     - name: Create GitHub release
       uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
       with:
         files: dist/*.tar.gz
         fail_on_unmatched_files: true


### PR DESCRIPTION
Because of all the targets, it took ~45 minutes to make a release. So split it into multiple jobs that pass the artifacts to a final deploy step.