### PR TITLE
Fixes for `pkgcheck scan --commit`

### DIFF
--- a/src/pkgcheck/checks/__init__.py
+++ b/src/pkgcheck/checks/__init__.py
@@ -100,6 +100,8 @@ class OptionalCheck(Check):
 class GitCommitsCheck(OptionalCheck):
     """Check that is only run when explicitly enabled via the --commits git option."""
 
+    runner_cls = runners.SequentialCheckRunner
+
     def __init__(self, *args):
         super().__init__(*args)
         if not self.options.commits:

--- a/src/pkgcheck/runners.py
+++ b/src/pkgcheck/runners.py
@@ -92,6 +92,15 @@ class RepoCheckRunner(SyncCheckRunner):
             yield from check.finish()
 
 
+class SequentialCheckRunner(SyncCheckRunner):
+    """Generic runner for sequential checks.
+
+    Checks that must not be run in parallel, will be run on the main process.
+    """
+
+    type = 'sequential'
+
+
 class AsyncCheckRunner(CheckRunner):
     """Generic runner for asynchronous checks.
 


### PR DESCRIPTION
Add a special runner which is run only on main process, and after the synchronous runners. This is useful for runners which must not be run in parallel, like the git checks.

Resolves: https://github.com/pkgcore/pkgcheck/issues/326