### PR TITLE
GitPkgCommitsCheck: fix archival repo from multiple removals

### DIFF
--- a/src/pkgcheck/checks/git.py
+++ b/src/pkgcheck/checks/git.py
@@ -7,6 +7,7 @@ import tarfile
 from collections import defaultdict
 from datetime import datetime
 from itertools import chain
+from operator import attrgetter
 from tempfile import TemporaryDirectory
 from urllib.parse import urlparse
 
@@ -204,10 +205,11 @@ class _RemovalRepo(UnconfiguredTree):
 
     def _populate(self, pkgs):
         """Populate the repo with a given sequence of historical packages."""
-        pkg = pkgs[0]
+        pkg = min(pkgs, key=attrgetter('time'))
         paths = [pjoin(pkg.category, pkg.package)]
-        if os.path.exists(pjoin(self.__parent_repo.location, 'eclass')):
-            paths.append('eclass')
+        for subdir in ('eclass', 'profiles'):
+            if os.path.exists(pjoin(self.__parent_repo.location, subdir)):
+                paths.append(subdir)
         old_files = subprocess.Popen(
             ['git', 'archive', f'{pkg.commit}~1'] + paths,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE,


### PR DESCRIPTION
When we are performing `--commits` scan over a commit range that have at least 2 commits that drop a version from the same package, we can have a state of the temporary "removal repo" that it expects one of the removed ebuilds.

This is because the check is fed package after package, with the list of all removals of this package in a list. When creating the archival repo, we need to select the commit from which to "archive", and we select the first commit in the list. This is not always the right commit, as it can be the second or third commit that removes the a version. As a result we have an archival repo that expects all version to exist, but one of them might be missing.

By selecting the commit with the lowest commit date, we ensure the right commit is selected, and all removed ebuilds are present.

On the same note, sometimes we have another exception, which involves a failure to check the EAPI of the repo is supported, because of missing `profiles` directory in archival repo, so also include it in the archive.

Resolves: https://github.com/pkgcore/pkgcheck/issues/460

@mgorny Can you please also verify that this patch fixes the issue you reported (it fixes for me, but you know...)