### PR TITLE
PythonCheck: warn about use of distutils-r1 non-PEP517 mode

### DIFF
--- a/testdata/data/repos/python/PythonCheck/DistutilsNonPEP517Build/expected.json
+++ b/testdata/data/repos/python/PythonCheck/DistutilsNonPEP517Build/expected.json
@@ -1,0 +1,1 @@
+{"__class__": "DistutilsNonPEP517Build", "category": "PythonCheck", "package": "DistutilsNonPEP517Build", "version": "0"}

--- a/testdata/data/repos/python/PythonCheck/DistutilsNonPEP517Build/fix.patch
+++ b/testdata/data/repos/python/PythonCheck/DistutilsNonPEP517Build/fix.patch
@@ -1,0 +1,10 @@
+diff -Naur python/PythonCheck/DistutilsNonPEP517Build/DistutilsNonPEP517Build-0.ebuild fixed/PythonCheck/DistutilsNonPEP517Build/DistutilsNonPEP517Build-0.ebuild
+--- python/PythonCheck/DistutilsNonPEP517Build/DistutilsNonPEP517Build-0.ebuild	2022-10-13 15:21:07.676924455 +0200
++++ fixed/PythonCheck/DistutilsNonPEP517Build/DistutilsNonPEP517Build-0.ebuild	2022-10-13 15:24:54.005682963 +0200
+@@ -1,5 +1,6 @@
+ EAPI=7
+ 
++DISTUTILS_USE_PEP517=setuptools
+ PYTHON_COMPAT=( python3_10 )
+ 
+ inherit distutils-r1

--- a/testdata/repos/python/PythonCheck/DistutilsNonPEP517Build/DistutilsNonPEP517Build-0.ebuild
+++ b/testdata/repos/python/PythonCheck/DistutilsNonPEP517Build/DistutilsNonPEP517Build-0.ebuild
@@ -1,0 +1,10 @@
+EAPI=7
+
+PYTHON_COMPAT=( python3_10 )
+
+inherit distutils-r1
+
+DESCRIPTION="Ebuild using non-PEP517 build"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+LICENSE="BSD"
+SLOT="0"


### PR DESCRIPTION
Closes: https://github.com/pkgcore/pkgcheck/issues/467