### PR TITLE
DescriptionCheck: catch ending with a full stop

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -14,6 +14,9 @@ pkgcheck 0.10.40 (unreleased)
 - StabilizationGroupsCheck: check for invalid and non-existant stabilization
   groups  (Arthur Zamarin)
 
+- DescriptionCheck: check for descriptions ending with a full-stop  (Arthur
+  Zamarin and Michał Górny)
+
 
 **Packaging:**
 

--- a/src/pkgcheck/checks/metadata.py
+++ b/src/pkgcheck/checks/metadata.py
@@ -1515,18 +1515,22 @@ class DescriptionCheck(Check):
     """DESCRIPTION checks.
 
     Check on length (<=80), too short (<10), or generic (lifted from eclass or
-    just using the package's name).
+    just using the package's name), or ending with a full stop.
     """
 
     known_results = frozenset([BadDescription])
 
     def feed(self, pkg):
-        desc = pkg.description
+        desc: str = pkg.description
         s = desc.lower()
         if s.startswith("based on") and "eclass" in s:
             yield BadDescription("generic eclass defined description", pkg_desc=desc, pkg=pkg)
         elif s in (pkg.package.lower(), pkg.key.lower()):
             yield BadDescription("generic package description", pkg_desc=desc, pkg=pkg)
+        elif desc.endswith(tuple(".,:;")) and not desc.lower().endswith(
+            ("etc.", "co.", "inc.", "ltd.", "...")
+        ):
+            yield BadDescription("ends with a full stop", pkg_desc=desc, pkg=pkg)
         else:
             desc_len = len(desc)
             if not desc_len:

--- a/testdata/data/repos/standalone/DescriptionCheck/BadDescription/fix.patch
+++ b/testdata/data/repos/standalone/DescriptionCheck/BadDescription/fix.patch
@@ -37,7 +37,7 @@ diff -Naur standalone/DescriptionCheck/BadDescription/BadDescription-4.ebuild fi
 --- standalone/DescriptionCheck/BadDescription/BadDescription-4.ebuild	2019-11-28 00:33:38.457040594 -0700
 +++ fixed/DescriptionCheck/BadDescription/BadDescription-4.ebuild	2019-11-28 00:34:59.065514420 -0700
 @@ -1,4 +1,4 @@
--DESCRIPTION="Ebuild with DESCRIPTION that is far too long and will be flagged by the BadDescription result since the check triggers at greater than 150 characters long."
+-DESCRIPTION="Ebuild with DESCRIPTION that is far too long and will be flagged by the BadDescription result since the check triggers at greater than 150 characters long"
 +DESCRIPTION="Ebuild with a sane DESCRIPTION"
  HOMEPAGE="https://github.com/pkgcore/pkgcheck"
  LICENSE="BSD"

--- a/testdata/repos/standalone/DescriptionCheck/BadDescription/BadDescription-4.ebuild
+++ b/testdata/repos/standalone/DescriptionCheck/BadDescription/BadDescription-4.ebuild
@@ -1,4 +1,4 @@
-DESCRIPTION="Ebuild with DESCRIPTION that is far too long and will be flagged by the BadDescription result since the check triggers at greater than 150 characters long."
+DESCRIPTION="Ebuild with DESCRIPTION that is far too long and will be flagged by the BadDescription result since the check triggers at greater than 150 characters long"
 HOMEPAGE="https://github.com/pkgcore/pkgcheck"
 LICENSE="BSD"
 SLOT="0"

--- a/tests/checks/test_metadata.py
+++ b/tests/checks/test_metadata.py
@@ -26,13 +26,32 @@ class TestDescriptionCheck(misc.ReportTestCase):
     def mk_pkg(self, desc=""):
         return misc.FakePkg("dev-util/diffball-0.7.1", data={"DESCRIPTION": desc})
 
-    def test_good_desc(self):
-        self.assertNoReport(self.check, self.mk_pkg("a perfectly written package description"))
+    @pytest.mark.parametrize(
+        "desc",
+        (
+            "a perfectly written package description",
+            "foo, bar, etc.",
+            "something something something...",
+        ),
+    )
+    def test_good_desc(self, desc: str):
+        self.assertNoReport(self.check, self.mk_pkg(desc))
 
-    def test_bad_descs(self):
-        for desc in ("based on eclass", "diffball", "dev-util/diffball", "foon"):
-            r = self.assertReport(self.check, self.mk_pkg(desc))
-            assert isinstance(r, metadata.BadDescription)
+    @pytest.mark.parametrize(
+        "desc",
+        (
+            "based on eclass",
+            "diffball",
+            "dev-util/diffball",
+            "foon",
+            "some kind of description.",
+            "some kind of description,",
+            "some kind of description..",
+        ),
+    )
+    def test_bad_descs(self, desc: str):
+        r = self.assertReport(self.check, self.mk_pkg(desc))
+        assert isinstance(r, metadata.BadDescription)
 
     def test_desc_length(self):
         r = self.assertReport(self.check, self.mk_pkg())


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/729968

<details>
  <summary>results on gentoo tree</summary>

  ```
  app-crypt/jacksum
    BadDescription: version 1.7.0-r1: DESCRIPTION="Java utility for computing and verifying checksums: CRC*, MD*, etc." ends with a full stop
  
  app-office/lyx
    BadDescription: version 2.3.6.1-r1: DESCRIPTION="WYSIWYM frontend for LaTeX, DocBook, etc." ends with a full stop
  
  app-xemacs/escreen
    BadDescription: version 1.03: DESCRIPTION="Multiple editing sessions withing a single frame (like screen).." ends with a full stop
  
  app-xemacs/reftex
    BadDescription: version 1.36: DESCRIPTION="Emacs support for LaTeX cross-references, citations.." ends with a full stop
  
  app-xemacs/sun
    BadDescription: version 1.19: DESCRIPTION="Support for Sparcworks.." ends with a full stop
  
  dev-embedded/sunxi-tools
    BadDescription: version 1.4.1-r1: DESCRIPTION="Tools for Allwinner A10 devices." ends with a full stop
  
  dev-games/libsmacker
    BadDescription: version 1.2.0_p43: DESCRIPTION="A cross-platform C library for decoding .smk Smacker Video files." ends with a full stop
  
  dev-java/commons-imaging
    BadDescription: version 1.0_alpha3: DESCRIPTION="Apache Commons Imaging (previously Sanselan) is a pure-Java image library." ends with a full stop
  
  dev-java/failureaccess
    BadDescription: version 30.1.1: DESCRIPTION="Guava's InternalFutureFailureAccess and InternalFutures classes." ends with a full stop
  
  dev-java/felix-resolver
    BadDescription: version 2.0.4: DESCRIPTION="Provide OSGi resolver service." ends with a full stop
  
  dev-java/hamcrest
    BadDescription: version 2.2: DESCRIPTION="Core API and libraries of hamcrest matcher framework." ends with a full stop
  
  dev-java/jackson-annotations
    BadDescription: version 2.13.3: DESCRIPTION="Core annotations used for value types, used by Jackson data binding package." ends with a full stop
    BadDescription: version 2.13.4: DESCRIPTION="Core annotations used for value types, used by Jackson data binding package." ends with a full stop
  
  dev-java/jansi
    BadDescription: version 2.4.0-r1: DESCRIPTION="Jansi is a java library for generating and interpreting ANSI escape sequences." ends with a full stop
  
  dev-java/javassist
    BadDescription: version 3.29.1: DESCRIPTION="A class library for editing bytecodes in Java." ends with a full stop
  
  dev-java/jaxb-stax-ex
    BadDescription: version 2.1.0-r1: DESCRIPTION="Extensions to JSR-173 StAX API." ends with a full stop
  
  dev-java/mchange-commons
    BadDescription: version 0.2.20: DESCRIPTION="a library of arguably useful Java utilities." ends with a full stop
  
  dev-java/memoryfilesystem
    BadDescription: version 2.3.0: DESCRIPTION="An in memory implementation of a JSR-203 file system." ends with a full stop
  
  dev-java/system-rules
    BadDescription: version 1.19.0: DESCRIPTION="A collection of JUnit rules for testing code which uses java.lang.System." ends with a full stop
  
  dev-java/treelayout
    BadDescription: version 1.0.3-r1: DESCRIPTION="Efficient and customizable TreeLayout Algorithm in Java." ends with a full stop
  
  dev-java/xerial-core
    BadDescription: version 2.0.1-r1: DESCRIPTION="Core library of the Xerial project." ends with a full stop
    BadDescription: version 2.1: DESCRIPTION="Core library of the Xerial project." ends with a full stop
  
  dev-perl/String-Truncate
    BadDescription: version 1.100.602-r1: DESCRIPTION="Module for when strings are too long to be displayed in..." ends with a full stop
  
  dev-perl/XML-Smart
    BadDescription: version 1.790.0-r1: DESCRIPTION="Access or create XML from fields, data and URLs." ends with a full stop
  
  dev-php/PEAR-PHP_Debug
    BadDescription: version 1.0.3-r3: DESCRIPTION="Provides traces, timings, executed queries, watched variables etc." ends with a full stop
  
  dev-python/pymacaroons
    BadDescription: version 0.13.0: DESCRIPTION="PyMacaroons is a Python implementation of Macaroons." ends with a full stop
  
  dev-python/pytest-param-files
    BadDescription: version 0.3.4: DESCRIPTION="Pytest parametrize decorators from external files." ends with a full stop
  
  dev-python/signedjson
    BadDescription: version 1.1.4: DESCRIPTION="Signs JSON objects with ED25519 signatures." ends with a full stop
  
  dev-python/whatthepatch
    BadDescription: version 1.0.2: DESCRIPTION="A patch parsing and application library." ends with a full stop
  
  dev-ruby/loofah
    BadDescription: version 2.14.0: DESCRIPTION="Library for manipulating and transforming HTML/XML documents and fragments." ends with a full stop
    BadDescription: version 2.15.0: DESCRIPTION="Library for manipulating and transforming HTML/XML documents and fragments." ends with a full stop
    BadDescription: version 2.18.0: DESCRIPTION="Library for manipulating and transforming HTML/XML documents and fragments." ends with a full stop
    BadDescription: version 2.19.0: DESCRIPTION="Library for manipulating and transforming HTML/XML documents and fragments." ends with a full stop
  
  dev-ruby/stringio
    BadDescription: version 3.0.1: DESCRIPTION="Pseudo IO class from/to String." ends with a full stop
    BadDescription: version 3.0.2: DESCRIPTION="Pseudo IO class from/to String." ends with a full stop
  
  dev-texlive/texlive-publishers
    BadDescription: version 2021: DESCRIPTION="TeXLive Publisher styles, theses, etc." ends with a full stop
  
  dev-util/breakpad
    BadDescription: version 2022.06.04: DESCRIPTION="implement a crash-reporting system." ends with a full stop
  
  dev-util/buildbot-badges
    BadDescription: version 3.4.0: DESCRIPTION="Buildbot badges plugin produces an image in SVG or PNG format..." ends with a full stop
    BadDescription: version 3.5.0: DESCRIPTION="Buildbot badges plugin produces an image in SVG or PNG format..." ends with a full stop
    BadDescription: version 3.6.0: DESCRIPTION="Buildbot badges plugin produces an image in SVG or PNG format..." ends with a full stop
    BadDescription: version 3.6.1: DESCRIPTION="Buildbot badges plugin produces an image in SVG or PNG format..." ends with a full stop
  
  dev-util/buildbot-www
    BadDescription: version 3.4.0: DESCRIPTION="BuildBot base web interface, use with buildbot-{console-view,waterfall-view}..." ends with a full stop
    BadDescription: version 3.5.0: DESCRIPTION="BuildBot base web interface, use with buildbot-{console-view,waterfall-view}..." ends with a full stop
    BadDescription: version 3.6.0: DESCRIPTION="BuildBot base web interface, use with buildbot-{console-view,waterfall-view}..." ends with a full stop
    BadDescription: version 3.6.1: DESCRIPTION="BuildBot base web interface, use with buildbot-{console-view,waterfall-view}..." ends with a full stop
  
  dev-util/cargo-ebuild
    BadDescription: version 0.5.1: DESCRIPTION="Generates an ebuild for a package using the in-tree eclasses." ends with a full stop
    BadDescription: version 0.5.2: DESCRIPTION="Generates an ebuild for a package using the in-tree eclasses." ends with a full stop
  
  dev-util/difftastic
    BadDescription: version 0.34.0: DESCRIPTION="A structural diff that understands syntax." ends with a full stop
    BadDescription: version 0.35.0: DESCRIPTION="A structural diff that understands syntax." ends with a full stop
    BadDescription: version 0.36.1: DESCRIPTION="A structural diff that understands syntax." ends with a full stop
  
  kde-plasma/kactivitymanagerd
    BadDescription: version 5.25.5: DESCRIPTION="System service to manage user's activities, track the usage patterns etc." ends with a full stop
    BadDescription: version 5.26.0: DESCRIPTION="System service to manage user's activities, track the usage patterns etc." ends with a full stop
  
  media-video/dvd_info
    BadDescription: version 1.1: DESCRIPTION="DVD utilities to print information, copy tracks, etc." ends with a full stop
  
  net-libs/libad9361-iio
    BadDescription: version 0.2: DESCRIPTION="IIO AD9361 library for filter design and handling, multi-chip sync, etc." ends with a full stop
  
  net-misc/mptcpd
    BadDescription: version 0.10-r1: DESCRIPTION="Daemon that performs multipath TCP path management related operations." ends with a full stop
    BadDescription: version 0.11: DESCRIPTION="Daemon that performs multipath TCP path management related operations." ends with a full stop
    BadDescription: version 9999: DESCRIPTION="Daemon that performs multipath TCP path management related operations." ends with a full stop
  
  net-p2p/arti
    BadDescription: version 0.6.0: DESCRIPTION="An implementation of Tor, in Rust." ends with a full stop
    BadDescription: version 1.0.0: DESCRIPTION="An implementation of Tor, in Rust." ends with a full stop
    BadDescription: version 1.0.1: DESCRIPTION="An implementation of Tor, in Rust." ends with a full stop
    BadDescription: version 9999: DESCRIPTION="An implementation of Tor, in Rust." ends with a full stop
  
  sci-physics/fastjet-contrib
    BadDescription: version 1.049-r1: DESCRIPTION="3rd party extensions of FastJet." ends with a full stop
  
  sys-apps/lsd
    BadDescription: version 0.23.1: DESCRIPTION="An ls command with a lot of pretty colors and some other stuff." ends with a full stop
  
  sys-apps/ripgrep-all
    BadDescription: version 0.9.6-r1: DESCRIPTION="Like ripgrep, but also search in PDFs, E-Books, Office documents, archives, etc." ends with a full stop
  
  sys-fs/reiser4progs
    BadDescription: version 1.2.1: DESCRIPTION="reiser4progs: mkfs, fsck, etc..." ends with a full stop
    BadDescription: version 2.0.5: DESCRIPTION="reiser4progs: mkfs, fsck, etc..." ends with a full stop
  
  sys-process/nmon
    BadDescription: version 16m: DESCRIPTION="Nigel's performance MONitor for CPU, memory, network, disks, etc..." ends with a full stop
  
  x11-misc/set_opacity
    BadDescription: version 1.0: DESCRIPTION="Tool for set real compositing for windows through window's id, process' pid etc." ends with a full stop
    BadDescription: version 9999: DESCRIPTION="Tool for set real compositing for windows through window's id, process' pid etc." ends with a full stop
  ```

</details>