### PR TITLE
VirtualProvidersCheck: new check for providers issues

### DIFF
--- a/testdata/data/repos/standalone/VirtualProvidersCheck/VirtualWithBdepend/expected.json
+++ b/testdata/data/repos/standalone/VirtualProvidersCheck/VirtualWithBdepend/expected.json
@@ -1,0 +1,2 @@
+{"__class__": "VirtualWithBdepend", "category": "virtual", "package": "VirtualWithBdepend", "version": "0"}
+{"__class__": "VirtualWithBdepend", "category": "virtual", "package": "VirtualWithBdepend", "version": "1"}

--- a/testdata/data/repos/standalone/VirtualProvidersCheck/VirtualWithDepend/expected.json
+++ b/testdata/data/repos/standalone/VirtualProvidersCheck/VirtualWithDepend/expected.json
@@ -1,0 +1,2 @@
+{"__class__": "VirtualWithDepend", "category": "virtual", "package": "VirtualWithDepend", "version": "0"}
+{"__class__": "VirtualWithDepend", "category": "virtual", "package": "VirtualWithDepend", "version": "1"}

--- a/testdata/data/repos/standalone/VirtualProvidersCheck/VirtualWithSingleProvider/expected.json
+++ b/testdata/data/repos/standalone/VirtualProvidersCheck/VirtualWithSingleProvider/expected.json
@@ -1,0 +1,1 @@
+{"__class__": "VirtualWithSingleProvider", "category": "virtual", "package": "VirtualWithSingleProvider4", "provider": "stub/slotted"}

--- a/testdata/repos/standalone/profiles/desc/elibc.desc
+++ b/testdata/repos/standalone/profiles/desc/elibc.desc
@@ -1,0 +1,1 @@
+glibc - ELIBC setting for systems that use the GNU C library

--- a/testdata/repos/standalone/profiles/package.deprecated
+++ b/testdata/repos/standalone/profiles/package.deprecated
@@ -1,0 +1,1 @@
+virtual/VirtualWithSingleProvider5

--- a/testdata/repos/standalone/virtual/VirtualWithBdepend/VirtualWithBdepend-0.ebuild
+++ b/testdata/repos/standalone/virtual/VirtualWithBdepend/VirtualWithBdepend-0.ebuild
@@ -1,0 +1,6 @@
+EAPI=7
+
+DESCRIPTION="Ebuild with unnecessary DEPEND"
+SLOT="0"
+
+BDEPEND="stub/stub1"

--- a/testdata/repos/standalone/virtual/VirtualWithBdepend/VirtualWithBdepend-1.ebuild
+++ b/testdata/repos/standalone/virtual/VirtualWithBdepend/VirtualWithBdepend-1.ebuild
@@ -1,0 +1,11 @@
+EAPI=7
+
+DESCRIPTION="Ebuild with unnecessary DEPEND"
+SLOT="0"
+
+RDEPEND="|| (
+	stub/stub1
+	stub/stub2
+)
+"
+BDEPEND="${RDEPEND}"

--- a/testdata/repos/standalone/virtual/VirtualWithDepend/VirtualWithDepend-0.ebuild
+++ b/testdata/repos/standalone/virtual/VirtualWithDepend/VirtualWithDepend-0.ebuild
@@ -1,0 +1,6 @@
+EAPI=7
+
+DESCRIPTION="Ebuild with unnecessary DEPEND"
+SLOT="0"
+
+DEPEND="stub/stub1"

--- a/testdata/repos/standalone/virtual/VirtualWithDepend/VirtualWithDepend-1.ebuild
+++ b/testdata/repos/standalone/virtual/VirtualWithDepend/VirtualWithDepend-1.ebuild
@@ -1,0 +1,11 @@
+EAPI=7
+
+DESCRIPTION="Ebuild with unnecessary DEPEND"
+SLOT="0"
+
+RDEPEND="|| (
+	stub/stub1
+	stub/stub2
+)
+"
+DEPEND="${RDEPEND}"

--- a/testdata/repos/standalone/virtual/VirtualWithSingleProvider1/VirtualWithSingleProvider1-0.ebuild
+++ b/testdata/repos/standalone/virtual/VirtualWithSingleProvider1/VirtualWithSingleProvider1-0.ebuild
@@ -1,0 +1,10 @@
+EAPI=7
+
+DESCRIPTION="Good virtual with 2 providers"
+SLOT="0"
+
+RDEPEND="|| (
+	stub/stub1
+	stub/stub2
+)
+"

--- a/testdata/repos/standalone/virtual/VirtualWithSingleProvider2/VirtualWithSingleProvider2-0.ebuild
+++ b/testdata/repos/standalone/virtual/VirtualWithSingleProvider2/VirtualWithSingleProvider2-0.ebuild
@@ -1,0 +1,10 @@
+EAPI=7
+
+DESCRIPTION="Good virtual with 1 provider but different use combinations"
+SLOT="0"
+
+RDEPEND="|| (
+	stub/stub1[matching]
+	stub/stub1[probable]
+)
+"

--- a/testdata/repos/standalone/virtual/VirtualWithSingleProvider3/VirtualWithSingleProvider3-0.ebuild
+++ b/testdata/repos/standalone/virtual/VirtualWithSingleProvider3/VirtualWithSingleProvider3-0.ebuild
@@ -1,0 +1,8 @@
+EAPI=7
+
+DESCRIPTION="Good virtual with 1 different provider across versions"
+SLOT="0"
+
+RDEPEND="
+	stub/stub1
+"

--- a/testdata/repos/standalone/virtual/VirtualWithSingleProvider3/VirtualWithSingleProvider3-1.ebuild
+++ b/testdata/repos/standalone/virtual/VirtualWithSingleProvider3/VirtualWithSingleProvider3-1.ebuild
@@ -1,0 +1,8 @@
+EAPI=7
+
+DESCRIPTION="Good virtual with 1 different provider across versions"
+SLOT="0"
+
+RDEPEND="
+	stub/stub2
+"

--- a/testdata/repos/standalone/virtual/VirtualWithSingleProvider4/VirtualWithSingleProvider4-0.ebuild
+++ b/testdata/repos/standalone/virtual/VirtualWithSingleProvider4/VirtualWithSingleProvider4-0.ebuild
@@ -1,0 +1,8 @@
+EAPI=7
+
+DESCRIPTION="Redundant virtual with 1 provider"
+SLOT="1"
+
+RDEPEND="
+	stub/slotted:${SLOT}
+"

--- a/testdata/repos/standalone/virtual/VirtualWithSingleProvider4/VirtualWithSingleProvider4-1.ebuild
+++ b/testdata/repos/standalone/virtual/VirtualWithSingleProvider4/VirtualWithSingleProvider4-1.ebuild
@@ -1,0 +1,8 @@
+EAPI=7
+
+DESCRIPTION="Redundant virtual with 1 provider"
+SLOT="1"
+
+RDEPEND="
+	stub/slotted:${SLOT}
+"

--- a/testdata/repos/standalone/virtual/VirtualWithSingleProvider5/VirtualWithSingleProvider5-0.ebuild
+++ b/testdata/repos/standalone/virtual/VirtualWithSingleProvider5/VirtualWithSingleProvider5-0.ebuild
@@ -1,0 +1,8 @@
+EAPI=7
+
+DESCRIPTION="Good virtual with 2 providers"
+SLOT="0"
+
+RDEPEND="
+	stub/stub1
+"

--- a/testdata/repos/standalone/virtual/VirtualWithSingleProvider6/VirtualWithSingleProvider6-0.ebuild
+++ b/testdata/repos/standalone/virtual/VirtualWithSingleProvider6/VirtualWithSingleProvider6-0.ebuild
@@ -1,0 +1,9 @@
+EAPI=7
+
+DESCRIPTION="virtual with 1 provider, but behind special use flags"
+SLOT="0"
+IUSE="elibc_glibc"
+
+RDEPEND="
+	!elibc_glibc? ( stub/stub1 )
+"


### PR DESCRIPTION
- check for virtual package defining DEPEND or BDEPEND
- check for virtual package with a single provider across versions
- All of them of `Warning` level

The logic for the single provider is:

1. Every version has one provider (compares full atom, for cases like when we depend on one of use flags)
2. Collecting all unversioned unslotted RDEPENDs gives us only one match --> to which we should replace the virtual.

Closes: https://bugs.gentoo.org/744784

<details>
  <summary>results over gentoo repo</summary>
  
  ```
  virtual/acl
    VirtualWithSingleProvider: virtual package with a single provider: sys-apps/acl
  
  virtual/blas
    VirtualWithDepend: version 3.8: virtual package with a DEPEND defined
  
  virtual/cblas
    VirtualWithDepend: version 3.8: virtual package with a DEPEND defined
  
  virtual/imap-c-client
    VirtualWithSingleProvider: virtual package with a single provider: net-libs/c-client
  
  virtual/jpeg
    VirtualWithSingleProvider: virtual package with a single provider: media-libs/libjpeg-turbo
  
  virtual/lapacke
    VirtualWithDepend: version 3.8-r1: virtual package with a DEPEND defined
  
  virtual/lapack
    VirtualWithDepend: version 3.8: virtual package with a DEPEND defined
    VirtualWithDepend: version 3.10: virtual package with a DEPEND defined
  
  virtual/libiconv
    VirtualWithSingleProvider: virtual package with a single provider: dev-libs/libiconv
  
  virtual/libintl
    VirtualWithSingleProvider: virtual package with a single provider: dev-libs/libintl
  
  virtual/linuxtv-dvb-headers
    VirtualWithSingleProvider: virtual package with a single provider: sys-kernel/linux-headers
  
  virtual/perl6
    VirtualWithSingleProvider: virtual package with a single provider: dev-lang/rakudo
  
  virtual/pkgconfig
    VirtualWithSingleProvider: virtual package with a single provider: dev-util/pkgconf
  
  virtual/ruby-ssl
    VirtualWithDepend: version 11: virtual package with a DEPEND defined
    VirtualWithBdepend: version 12: virtual package with a BDEPEND defined
    VirtualWithDepend: version 12: virtual package with a DEPEND defined
  
  virtual/rubygems
    VirtualWithBdepend: version 16: virtual package with a BDEPEND defined
    VirtualWithDepend: version 16: virtual package with a DEPEND defined
    VirtualWithBdepend: version 17: virtual package with a BDEPEND defined
    VirtualWithDepend: version 17: virtual package with a DEPEND defined
  
  virtual/tex-base
    VirtualWithSingleProvider: virtual package with a single provider: app-text/texlive-core
  ```
</details>

---

- [ ] Handle the case of `virtual/libiconv` and `virtual/libintl`