### PR TITLE
AcctCheck: use `metadata/qa-policy.conf` for dynamic id range

### DIFF
--- a/src/pkgcheck/checks/acct.py
+++ b/src/pkgcheck/checks/acct.py
@@ -2,14 +2,16 @@
 
 import re
 from collections import defaultdict
+from configparser import ConfigParser
 from functools import partial
 from itertools import chain
 
 from pkgcore.ebuild import restricts
 from pkgcore.restrictions import packages
+from snakeoil.osutils import pjoin
 
 from .. import results, sources
-from . import GentooRepoCheck, RepoCheck
+from . import GentooRepoCheck, RepoCheck, SkipCheck
 
 
 class MissingAccountIdentifier(results.VersionResult, results.Warning):
@@ -35,13 +37,16 @@ class ConflictingAccountIdentifiers(results.Error):
 
     @property
     def desc(self):
-        return (
-            f"conflicting {self.kind} id {self.identifier} usage: "
-            f"[ {', '.join(self.pkgs)} ]")
+        pkgs = ', '.join(self.pkgs)
+        return f"conflicting {self.kind} id {self.identifier} usage: [ {pkgs} ]"
 
 
 class OutsideRangeAccountIdentifier(results.VersionResult, results.Error):
-    """UID/GID outside allowed allocation range."""
+    """UID/GID outside allowed allocation range.
+
+    To view the range accepted for this repository, look at the file
+    ``metadata/qa-policy.conf`` in the section ``user-group-ids``.
+    """
 
     def __init__(self, kind, identifier, **kwargs):
         super().__init__(**kwargs)
@@ -50,16 +55,20 @@ class OutsideRangeAccountIdentifier(results.VersionResult, results.Error):
 
     @property
     def desc(self):
-        return (
-            f"{self.kind} id {self.identifier} outside permitted "
-            f"static allocation range (0..499, 60001+)")
+        return (f"{self.kind} id {self.identifier} outside permitted "
+            f"static allocation range")
 
 
 class AcctCheck(GentooRepoCheck, RepoCheck):
     """Various checks for acct-* packages.
 
     Verify that acct-* packages do not use conflicting, invalid or out-of-range
-    UIDs/GIDs.
+    UIDs/GIDs. This check uses a special file ``metadata/qa-policy.conf``
+    located within the repository. It should contain a ``user-group-ids``
+    section containing two keys: ``uid-range`` and ``gid-range``, which consist
+    of a comma separated list, either ``<n>`` for a single value or ``<m>-<n>``
+    for a range of values (including both ends). In case this file doesn't
+    exist or is wrongly defined, this check is skipped.
     """
 
     _restricted_source = (sources.RestrictionRepoSource, (packages.OrRestriction(*(
@@ -76,14 +85,37 @@ class AcctCheck(GentooRepoCheck, RepoCheck):
             r'ACCT_(?P<var>USER|GROUP)_ID=(?P<quot>[\'"]?)(?P<id>[0-9]+)(?P=quot)')
         self.seen_uids = defaultdict(partial(defaultdict, list))
         self.seen_gids = defaultdict(partial(defaultdict, list))
+        uid_range, gid_range = self.load_ids_from_configuration(self.options.target_repo)
         self.category_map = {
-            'acct-user': (self.seen_uids, 'USER', (65534,)),
-            'acct-group': (self.seen_gids, 'GROUP', (65533, 65534)),
+            'acct-user': (self.seen_uids, 'USER', tuple(uid_range)),
+            'acct-group': (self.seen_gids, 'GROUP', tuple(gid_range)),
         }
+
+    def parse_config_id_range(self, config: ConfigParser, config_key: str):
+        id_ranges = config['user-group-ids'].get(config_key, None)
+        if not id_ranges:
+            raise SkipCheck(self, f"metadata/qa-policy.conf: missing value for {config_key}")
+        try:
+            for id_range in map(str.strip, id_ranges.split(',')):
+                start, *end = map(int, id_range.split('-', maxsplit=1))
+                if len(end) == 0:
+                    yield range(start, start + 1)
+                else:
+                    yield range(start, end[0] + 1)
+        except ValueError:
+            raise SkipCheck(self, f"metadata/qa-policy.conf: invalid value for {config_key}")
+
+    def load_ids_from_configuration(self, repo):
+        config = ConfigParser()
+        if not config.read(pjoin(repo.location, 'metadata', 'qa-policy.conf')):
+            raise SkipCheck(self, "failed loading 'metadata/qa-policy.conf'")
+        if 'user-group-ids' not in config:
+            raise SkipCheck(self, "metadata/qa-policy.conf: missing section user-group-ids")
+        return self.parse_config_id_range(config, 'uid-range'), self.parse_config_id_range(config, 'gid-range')
 
     def feed(self, pkg):
         try:
-            seen_id_map, expected_var, extra_allowed_ids = self.category_map[pkg.category]
+            seen_id_map, expected_var, allowed_ids = self.category_map[pkg.category]
         except KeyError:
             return
 
@@ -96,9 +128,7 @@ class AcctCheck(GentooRepoCheck, RepoCheck):
             yield MissingAccountIdentifier(f"ACCT_{expected_var}_ID", pkg=pkg)
             return
 
-        # all UIDs/GIDs must be in <750, with special exception
-        # of nobody/nogroup which use 65534/65533
-        if found_id >= 750 and found_id not in extra_allowed_ids:
+        if not any(found_id in id_range for id_range in allowed_ids):
             yield OutsideRangeAccountIdentifier(expected_var.lower(), found_id, pkg=pkg)
             return
 


### PR DESCRIPTION
Load UID and GID range from `metadata/qa-policy.conf` under the repo, validate the format is as expected, and use the values to set expected ids.

Resolves: https://github.com/pkgcore/pkgcheck/issues/356

---

I mainly need a review of the class' docs changes I did, that they are sane.