### PR TITLE
NonPosixHeadTailUsage: new check

### DIFF
--- a/testdata/data/repos/standalone/NonPosixCheck/NonPosixHeadTailUsage/expected.json
+++ b/testdata/data/repos/standalone/NonPosixCheck/NonPosixHeadTailUsage/expected.json
@@ -1,0 +1,5 @@
+{"__class__": "NonPosixHeadTailUsage", "category": "NonPosixCheck", "package": "NonPosixHeadTailUsage", "version": "0", "line": "head -1 file", "lineno": 7, "command": "head -1"}
+{"__class__": "NonPosixHeadTailUsage", "category": "NonPosixCheck", "package": "NonPosixHeadTailUsage", "version": "0", "line": "head -q file -1", "lineno": 8, "command": "head -1"}
+{"__class__": "NonPosixHeadTailUsage", "category": "NonPosixCheck", "package": "NonPosixHeadTailUsage", "version": "1", "line": "tail -1 file", "lineno": 7, "command": "tail -1"}
+{"__class__": "NonPosixHeadTailUsage", "category": "NonPosixCheck", "package": "NonPosixHeadTailUsage", "version": "1", "line": "tail -q file -1", "lineno": 8, "command": "tail -1"}
+{"__class__": "NonPosixHeadTailUsage", "category": "NonPosixCheck", "package": "NonPosixHeadTailUsage", "version": "1", "line": "tail -qn file +1", "lineno": 9, "command": "tail +1"}

--- a/testdata/data/repos/standalone/NonPosixCheck/NonPosixHeadTailUsage/fix.patch
+++ b/testdata/data/repos/standalone/NonPosixCheck/NonPosixHeadTailUsage/fix.patch
@@ -1,0 +1,26 @@
+--- standalone/NonPosixCheck/NonPosixHeadTailUsage/NonPosixHeadTailUsage-0.ebuild
++++ fixed/NonPosixCheck/NonPosixHeadTailUsage/NonPosixHeadTailUsage-0.ebuild
+@@ -4,7 +4,7 @@ SLOT="0"
+ LICENSE="BSD"
+
+ src_prepare() {
+-	head -1 file > another || die
+-	head -q file -1 > another || die
++	head -n -1 file > another || die
++	head -qn 1 file > another || die
+ 	default
+ }
+--- standalone/NonPosixCheck/NonPosixHeadTailUsage/NonPosixHeadTailUsage-1.ebuild
++++ fixed/NonPosixCheck/NonPosixHeadTailUsage/NonPosixHeadTailUsage-1.ebuild
+@@ -4,8 +4,8 @@ SLOT="0"
+ LICENSE="BSD"
+
+ src_prepare() {
+-	tail -1 file > another || die
+-	tail -q file -1 > another || die
+-	tail -qn file +1 > another || die
++	tail -n 1 file > another || die
++	tail -q file -c 1 > another || die
++	tail file -qn +1 > another || die
+ 	default
+ }

--- a/testdata/repos/standalone/NonPosixCheck/NonPosixHeadTailUsage/NonPosixHeadTailUsage-0.ebuild
+++ b/testdata/repos/standalone/NonPosixCheck/NonPosixHeadTailUsage/NonPosixHeadTailUsage-0.ebuild
@@ -1,0 +1,10 @@
+DESCRIPTION="Ebuild with non posix head usage"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"
+
+src_prepare() {
+	head -1 file > another || die
+	head -q file -1 > another || die
+	default
+}

--- a/testdata/repos/standalone/NonPosixCheck/NonPosixHeadTailUsage/NonPosixHeadTailUsage-1.ebuild
+++ b/testdata/repos/standalone/NonPosixCheck/NonPosixHeadTailUsage/NonPosixHeadTailUsage-1.ebuild
@@ -1,0 +1,11 @@
+DESCRIPTION="Ebuild with non posix head usage"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"
+
+src_prepare() {
+	tail -1 file > another || die
+	tail -q file -1 > another || die
+	tail -qn file +1 > another || die
+	default
+}


### PR DESCRIPTION
New warning for non-POSIX compliant head or tail without -n.

Closes: https://bugs.gentoo.org/558360