### PR TITLE
Fix API compatibility w/ pkgcore revision eb6f4edd2

### DIFF
--- a/src/pkgcheck/checks/metadata.py
+++ b/src/pkgcheck/checks/metadata.py
@@ -210,11 +210,10 @@ class IuseCheck(Check):
     def __init__(self, *args, use_addon):
         super().__init__(*args)
         self.iuse_handler = use_addon
-        self.valid_use = atom_mod.valid_use_flag.match
         self.bad_defaults = tuple(['-'] + [f'+{x}_' for x in self.use_expand_groups])
 
     def feed(self, pkg):
-        if invalid := sorted(x for x in pkg.iuse_stripped if not self.valid_use(x)):
+        if invalid := sorted(x for x in pkg.iuse_stripped if not pkg.eapi.is_valid_use_flag(x)):
             yield InvalidUseFlags(invalid, pkg=pkg)
 
         if pkg.eapi.options.iuse_defaults and (bad_defaults := sorted(


### PR DESCRIPTION
In that revision, USE flag validation is moved to eapi objects; EAPI ultimately arbitrates that, and it cleaned up some internal issues in atom.

However, it broke pkgcheck's metadata check which was using that regex directly; that code's broken anyways- any demandloaded object must not be imported into another scope; the lazy replacement only affects the original scope, thus that `self.valid_use = ` was pinning the proxied regex.

Either way; since EAPI objects now have a use flag validation method, use that.

Fixes pkgcore/pkgcheck#502

Signed-off-by: Brian Harring <ferringb@gmail.com>