### PR TITLE
EclassUsageCheck: check for setting user variables in ebuilds

### DIFF
--- a/testdata/data/repos/eclass/EclassUsageCheck/EclassUserVariableUsage/expected.json
+++ b/testdata/data/repos/eclass/EclassUsageCheck/EclassUserVariableUsage/expected.json
@@ -1,0 +1,1 @@
+{"__class__": "EclassUserVariableUsage", "category": "EclassUsageCheck", "package": "EclassUserVariableUsage", "version": "0", "line": "EBZR_STORE_DIR", "lineno": 8, "eclass": "unquotedvariable"}

--- a/testdata/repos/eclass/EclassUsageCheck/EclassUserVariableUsage/EclassUserVariableUsage-0.ebuild
+++ b/testdata/repos/eclass/EclassUsageCheck/EclassUserVariableUsage/EclassUserVariableUsage-0.ebuild
@@ -1,0 +1,12 @@
+EAPI=8
+inherit unquotedvariable
+DESCRIPTION="Ebuild with user variable override"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"
+
+EBZR_STORE_DIR="/var/tmp/portage" # FAIL
+
+src_prepare() {
+    echo "${EBZR_STORE_DIR}" # ok
+}


### PR DESCRIPTION
Check ebuilds for overriding eclass' user variables.

Resolves: https://github.com/pkgcore/pkgcheck/issues/512