### PR TITLE
InvalidMetadataRestrict: check for invalid restricts in metadata.xml

### DIFF
--- a/testdata/data/repos/gentoo/PackageMetadataXmlCheck/InvalidMetadataRestrict/expected.json
+++ b/testdata/data/repos/gentoo/PackageMetadataXmlCheck/InvalidMetadataRestrict/expected.json
@@ -1,0 +1,1 @@
+{"__class__": "InvalidMetadataRestrict", "category": "PackageMetadataXmlCheck", "package": "InvalidMetadataRestrict", "restrict": "<=PackageMetadataXmlCheck2/InvalidMetadataRestrict-5", "msg": "references another package"}

--- a/testdata/repos/gentoo/PackageMetadataXmlCheck/InvalidMetadataRestrict/InvalidMetadataRestrict-0.ebuild
+++ b/testdata/repos/gentoo/PackageMetadataXmlCheck/InvalidMetadataRestrict/InvalidMetadataRestrict-0.ebuild
@@ -1,0 +1,8 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+DESCRIPTION="Package metadata.xml with invalid restrict"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"
+IUSE="flag1"

--- a/testdata/repos/gentoo/PackageMetadataXmlCheck/InvalidMetadataRestrict/metadata.xml
+++ b/testdata/repos/gentoo/PackageMetadataXmlCheck/InvalidMetadataRestrict/metadata.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person" restrict="&lt;=PackageMetadataXmlCheck2/InvalidMetadataRestrict-5">
+		<email>random.gentoo.dev@gentoo.org</email>
+	</maintainer>
+	<use>
+		<flag name="flag1" restrict="&lt;=PackageMetadataXmlCheck/InvalidMetadataRestrict-5">Some explanation</flag>
+	</use>
+</pkgmetadata>


### PR DESCRIPTION
Signed-off-by: Arthur Zamarin <arthurzam@gentoo.org>