### PR TITLE
skip annotations for version results

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,6 +10,18 @@ Contents:
     news
     api
     man/pkgcheck
+    man/pkgcheck/scan
+    man/pkgcheck/keywords
+    man/pkgcheck/checks
+    man/config
+    man/skip
+
+Reporting Bugs
+==============
+
+Please submit an issue via github:
+
+https://github.com/pkgcore/pkgcheck/issues
 
 Indices and tables
 ==================

--- a/doc/man/pkgcheck.rst
+++ b/doc/man/pkgcheck.rst
@@ -12,6 +12,7 @@ pkgcheck
 .. include:: pkgcheck/reporters.rst
 
 .. include:: config.rst
+.. include:: skip.rst
 
 Reporting Bugs
 ==============

--- a/doc/man/skip.rst
+++ b/doc/man/skip.rst
@@ -1,0 +1,28 @@
+Skip results annotations
+========================
+
+pkgcheck supports skipping ebuilds results via special annotation. This is
+useful in cases where you are aware of false positive in pkgcheck check, and
+fixing pkgcheck is hard or impossible.
+
+The annotation must appear in the ebuild before any non-comment non-empty line
+(most of the times it would be just before the EAPI declaration line and after
+the copyright lines). Empty lines between the copyright and the annotation are
+allowed.
+
+You can't skip *error* level results. Skipping *warning* level results requires
+QA team member approval (should include name and RFC 3339 data). *info* and
+*style* level can be skipped without approval. Do consider to just ignore them
+instead of skipping.
+
+An example of skipping a *info* and *warning* level results::
+
+    # Copyright 2023 Gentoo Authors
+    # Distributed under the terms of the GNU General Public License v2
+
+    # pkgcheck skip: PythonCompatUpdate
+
+    # Approved by larry 2023-04-31
+    # pkgcheck skip: VariableScope
+
+    EAPI=8

--- a/src/pkgcheck/results.py
+++ b/src/pkgcheck/results.py
@@ -225,6 +225,12 @@ class VersionResult(PackageResult):
         self.version = pkg.fullver
         self._attr = "version"
 
+        if (
+            self.__class__.__name__ in getattr(pkg, "skipped_results", ())
+            and getattr(self, "level", "") != "error"
+        ):
+            self._filtered = True
+
     @klass.jit_attr
     def ver_rev(self):
         version, _, revision = self.version.partition("-r")

--- a/testdata/repos/standalone/DoCompressedFilesCheck/InstallCompressedInfo/InstallCompressedInfo-1.ebuild
+++ b/testdata/repos/standalone/DoCompressedFilesCheck/InstallCompressedInfo/InstallCompressedInfo-1.ebuild
@@ -1,0 +1,13 @@
+# pkgcheck skip: InstallCompressedInfo
+
+EAPI=7
+
+DESCRIPTION="Ebuild installing compressed info, but with result marked skipped"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"
+
+src_install() {
+	doinfo 'test.gz' "${PN}.bz2"
+	doinfo "${PN}"
+}


### PR DESCRIPTION
Add support for an ebuild to declare a skip annotation for a class of **version** results. This skip annotation must be declared before any non-comment non-empty line (most of the times it would be before the EAPI declaration). Empty lines between the copyright and the annotation are allowed.
The annotation line must be precise, only one class per line and every space is required.

For example, it would look like:
```bash
# Copyright 2023 Gentoo Authors
# Distributed under the terms of the GNU General Public License v2

# pkgcheck skip: PythonCompatUpdate

# Approved by larry 2023-04-31
# pkgcheck skip: VariableScope

EAPI=8
```

Resolves: https://github.com/pkgcore/pkgcheck/issues/478

## More thoughts

1. Is the format fine?
2. Before merge to master/before release, we must define a QA policy who and when can add a skip.
   As preliminary idea from me (non QA member!): error none, warning only with QA approval, info/style anyone?
3. Am I too hard with the syntax and placing?
4. How and if we should support annotation for package ("dir") results?
5. Should I support multiple class names in same line, separated with commas?
6. Should I add special syntax for placing QA member name and date for those that require approval?
7. Should I post to -dev ML when ready?

TODO:

- [ ] This should be just after EAPI line instead of before
- [ ] Should support comma separated list of classes on the same line
- [ ] Post to ML for comments
- [ ] Open Question for ML: auto approval on ebuild bump?