### PR TITLE
EbuildReservedCheck: check for semi-reserved names

### DIFF
--- a/src/pkgcheck/bash/__init__.py
+++ b/src/pkgcheck/bash/__init__.py
@@ -1,6 +1,5 @@
 """bash parsing support"""
 
-from functools import partial
 import os
 
 from snakeoil.osutils import pjoin
@@ -100,7 +99,7 @@ except ImportError:  # pragma: no cover
 
 if syslib is not None or os.path.exists(lib):
     lang = Language(syslib or lib, "bash")
-    query = partial(lang.query)
+    query = lang.query
     parser = Parser()
     parser.set_language(lang)
 
@@ -114,7 +113,7 @@ if syslib is not None or os.path.exists(lib):
 class ParseTree:
     """Bash parse tree object and support."""
 
-    def __init__(self, data, **kwargs):
+    def __init__(self, data: bytes, **kwargs):
         super().__init__(**kwargs)
         self.data = data
         self.tree = parser.parse(data)

--- a/src/pkgcheck/checks/reserved.py
+++ b/src/pkgcheck/checks/reserved.py
@@ -1,4 +1,5 @@
 import re
+import string
 
 from pkgcore.ebuild.eapi import EAPI
 
@@ -22,7 +23,7 @@ class _ReservedNameCheck(Check):
     """Approved good exceptions to using of variables."""
     variables_usage_whitelist = {"EBUILD_PHASE", "EBUILD_PHASE_FUNC"}
 
-    def _check(self, used_type: str, used_names):
+    def _check(self, used_type: str, used_names: dict[str, tuple[int, int]]):
         for used_name, (lineno, _) in used_names.items():
             if used_name in self.special_whitelist:
                 continue
@@ -36,7 +37,7 @@ class _ReservedNameCheck(Check):
             if self.reserved_ebuild_regex.match(test_name):
                 yield used_name, used_type, "ebuild", "substring", lineno + 1
 
-    def _feed(self, item):
+    def _feed(self, item: bash.ParseTree):
         yield from self._check(
             "function",
             {
@@ -82,7 +83,7 @@ class EclassReservedCheck(_ReservedNameCheck):
         super().__init__(*args)
         self.eclass_cache = eclass_addon.eclasses
 
-    def feed(self, eclass):
+    def feed(self, eclass: sources._ParsedEclass):
         for *args, _ in self._feed(eclass):
             yield EclassReservedName(*args, eclass=eclass.name)
 
@@ -101,11 +102,34 @@ class EbuildReservedName(results.LineResult, results.Warning):
         return f'line {self.lineno}: {self.used_type} name "{self.line}" is disallowed because "{self.reserved_word}" is a reserved {self.reserved_type}'
 
 
+class EbuildSemiReservedName(results.LineResult, results.Warning):
+    """Ebuild uses semi-reserved variable or function name.
+
+    Ebuild is using in global scope semi-reserved variable or function names,
+    which is likely to clash with future EAPIs. Currently it include
+    single-letter uppercase variables, and ``[A-Z]DEPEND`` variables.
+    """
+
+    def __init__(self, used_type: str, **kwargs):
+        super().__init__(**kwargs)
+        self.used_type = used_type
+
+    @property
+    def desc(self):
+        return f'line {self.lineno}: uses semi-reserved {self.used_type} name "{self.line}", likely to clash with future EAPIs'
+
+
 class EbuildReservedCheck(_ReservedNameCheck):
     """Scan ebuilds for reserved function or variable names."""
 
     _source = sources.EbuildParseRepoSource
-    known_results = frozenset([EbuildReservedName])
+    known_results = frozenset({EbuildReservedName, EbuildSemiReservedName})
+
+    global_reserved = (
+        frozenset(string.ascii_uppercase)
+        .union(c + "DEPEND" for c in string.ascii_uppercase)
+        .difference(("CDEPEND",))
+    )
 
     def __init__(self, options, **kwargs):
         super().__init__(options, **kwargs)
@@ -116,7 +140,7 @@ class EbuildReservedCheck(_ReservedNameCheck):
             for eapi_name, eapi in EAPI.known_eapis.items()
         }
 
-    def feed(self, pkg):
+    def feed(self, pkg: sources._ParsedPkg):
         for used_name, *args, lineno in self._feed(pkg):
             yield EbuildReservedName(*args, lineno=lineno, line=used_name, pkg=pkg)
 
@@ -126,4 +150,18 @@ class EbuildReservedCheck(_ReservedNameCheck):
                 lineno, _ = node.start_point
                 yield EbuildReservedName(
                     "function", used_name, "phase hook", lineno=lineno + 1, line=used_name, pkg=pkg
+                )
+
+        current_global_reserved = self.global_reserved.difference(
+            pkg.eapi.eclass_keys, pkg.eapi.dep_keys
+        )
+        for node in pkg.global_query(bash.var_assign_query):
+            used_name = pkg.node_str(node.child_by_field_name("name"))
+            if used_name in current_global_reserved:
+                lineno, _ = node.start_point
+                yield EbuildSemiReservedName(
+                    "variable",
+                    lineno=lineno + 1,
+                    line=used_name,
+                    pkg=pkg,
                 )

--- a/testdata/data/repos/standalone/EbuildReservedCheck/EbuildSemiReservedName/expected.json
+++ b/testdata/data/repos/standalone/EbuildReservedCheck/EbuildSemiReservedName/expected.json
@@ -1,0 +1,5 @@
+{"__class__": "EbuildSemiReservedName", "category": "DependencyCheck", "package": "MisplacedWeakBlocker", "version": "6", "line": "BDEPEND", "lineno": 8, "used_type": "variable"}
+{"__class__": "EbuildSemiReservedName", "category": "DependencyCheck", "package": "MisplacedWeakBlocker", "version": "6", "line": "IDEPEND", "lineno": 12, "used_type": "variable"}
+{"__class__": "EbuildSemiReservedName", "category": "DependencyCheck", "package": "MisplacedWeakBlocker", "version": "7", "line": "IDEPEND", "lineno": 12, "used_type": "variable"}
+{"__class__": "EbuildSemiReservedName", "category": "EbuildReservedCheck", "package": "EbuildSemiReservedName", "version": "0", "line": "B", "lineno": 9, "used_type": "variable"}
+{"__class__": "EbuildSemiReservedName", "category": "EbuildReservedCheck", "package": "EbuildSemiReservedName", "version": "0", "line": "TDEPEND", "lineno": 13, "used_type": "variable"}

--- a/testdata/repos/standalone/EbuildReservedCheck/EbuildSemiReservedName/EbuildSemiReservedName-0.ebuild
+++ b/testdata/repos/standalone/EbuildReservedCheck/EbuildSemiReservedName/EbuildSemiReservedName-0.ebuild
@@ -1,0 +1,13 @@
+EAPI=8
+
+DESCRIPTION="Ebuild with semi-reserved names"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"
+
+S=${WORKDIR}  # ok
+B=${WORKDIR}  # fail
+BDEPEND="app-arch/unzip"  # ok
+CDEPEND="app-arch/unzip"  # ok
+RDEPEND="${CDEPEND}"  # ok
+TDEPEND="app-arch/unzip"  # fail


### PR DESCRIPTION
<details><summary>Gentoo results</summary>

```
  app-editors/padre
    EbuildSemiReservedName: version 1.0.0-r2: line 19: uses semi-reserved variable name "TDEPEND", likely to clash with future EAPIs
  
  app-text/texlive-core
    EbuildSemiReservedName: version 2021-r2: line 133: uses semi-reserved variable name "B", likely to clash with future EAPIs
    EbuildSemiReservedName: version 2021-r3: line 134: uses semi-reserved variable name "B", likely to clash with future EAPIs
    EbuildSemiReservedName: version 2021-r6: line 134: uses semi-reserved variable name "B", likely to clash with future EAPIs
  
  dev-lang/mlton
    EbuildSemiReservedName: version 20180207: line 41: uses semi-reserved variable name "B", likely to clash with future EAPIs
    EbuildSemiReservedName: version 20180207: line 42: uses semi-reserved variable name "R", likely to clash with future EAPIs
  
  dev-libs/teakra
    EbuildSemiReservedName: version 20220224: line 6: uses semi-reserved variable name "H", likely to clash with future EAPIs
  
  dev-python/js2py
    EbuildSemiReservedName: version 0.71_p20210918: line 6: uses semi-reserved variable name "H", likely to clash with future EAPIs
  
  dev-python/pyjsparser
    EbuildSemiReservedName: version 2.7.1_p20190421-r2: line 6: uses semi-reserved variable name "H", likely to clash with future EAPIs
  
  dev-ruby/mysql2
    EbuildSemiReservedName: version 0.5.3-r1: line 28: uses semi-reserved variable name "MDEPEND", likely to clash with future EAPIs
    EbuildSemiReservedName: version 0.5.3.20210920: line 34: uses semi-reserved variable name "MDEPEND", likely to clash with future EAPIs
    EbuildSemiReservedName: version 0.5.4: line 31: uses semi-reserved variable name "MDEPEND", likely to clash with future EAPIs
    EbuildSemiReservedName: version 0.5.5: line 31: uses semi-reserved variable name "MDEPEND", likely to clash with future EAPIs
  
  dev-scheme/guile-libyaml
    EbuildSemiReservedName: version 20211124: line 6: uses semi-reserved variable name "H", likely to clash with future EAPIs
  
  net-wireless/horst
    EbuildSemiReservedName: version 5.1: line 21: uses semi-reserved variable name "TDEPEND", likely to clash with future EAPIs
    EbuildSemiReservedName: version 9999: line 21: uses semi-reserved variable name "TDEPEND", likely to clash with future EAPIs
  
  sci-mathematics/btor2tools
    EbuildSemiReservedName: version 1.0.0_pre20220518-r1: line 6: uses semi-reserved variable name "H", likely to clash with future EAPIs
  
  sci-mathematics/boolector
    EbuildSemiReservedName: version 3.2.2_p20220110: line 6: uses semi-reserved variable name "H", likely to clash with future EAPIs
  
  sci-mathematics/metamath-databases
    EbuildSemiReservedName: version 20220303: line 6: uses semi-reserved variable name "H", likely to clash with future EAPIs
  
  sci-mathematics/smtinterpol
    EbuildSemiReservedName: version 2.5_p20211018: line 6: uses semi-reserved variable name "H", likely to clash with future EAPIs
  
  x11-misc/screenkey
    EbuildSemiReservedName: version 1.5_p20230109: line 19: uses semi-reserved variable name "H", likely to clash with future EAPIs
  
  x11-wm/xpra
    EbuildSemiReservedName: version 4.3.3: line 34: uses semi-reserved variable name "TDEPEND", likely to clash with future EAPIs
    EbuildSemiReservedName: version 4.3.4: line 34: uses semi-reserved variable name "TDEPEND", likely to clash with future EAPIs
    EbuildSemiReservedName: version 9999: line 33: uses semi-reserved variable name "TDEPEND", likely to clash with future EAPIs
```
</details>