### PR TITLE
Fix config loading if XDG_CONFIG_HOME is defined

### DIFF
--- a/doc/man/config.rst
+++ b/doc/man/config.rst
@@ -4,10 +4,11 @@ Config file support
 Config files are supported by ``pkgcheck scan`` from any of four locations.
 Listed in order of increasing precedence these include the following:
 
-- system config -- /etc/pkgcheck/pkgcheck.conf
-- user config -- ~/.config/pkgcheck/pkgcheck.conf
-- repo config -- metadata/pkgcheck.conf inside an ebuild repo
-- custom config -- specified via the --config option
+- system config -- ``/etc/pkgcheck/pkgcheck.conf``
+- user config -- ``${XDG_CONFIG_HOME}/pkgcheck/pkgcheck.conf``
+- user config -- ``~/.config/pkgcheck/pkgcheck.conf``
+- repo config -- ``metadata/pkgcheck.conf`` inside an ebuild repo
+- custom config -- specified via the ``--config`` option
 
 Any settings from a config file with higher precedence will override matching
 settings from a config file with a lower precedence, e.g. repo settings

--- a/src/pkgcheck/const.py
+++ b/src/pkgcheck/const.py
@@ -32,7 +32,7 @@ for xdg_var, var_name, fallback_dir in (
     setattr(
         _module,
         var_name,
-        os.environ.get(xdg_var, os.path.join(os.path.expanduser(fallback_dir), "pkgcheck")),
+        os.path.join(os.environ.get(xdg_var, os.path.expanduser(fallback_dir)), "pkgcheck"),
     )
 
 REPO_PATH = _GET_CONST("REPO_PATH", _reporoot)


### PR DESCRIPTION
Similar issue to https://github.com/pkgcore/pkgdev/issues/72.  Applies a similar fix as https://github.com/pkgcore/pkgdev/commit/9f60576753da4cbe5cd0afe660d49a22e34e3cf1 to match what is already documented in the man page.