### PR TITLE
StaleLiveCheck: new check for stale live eapi

### DIFF
--- a/testdata/data/repos/standalone/StaleLiveCheck/StaleLiveEAPI/expected.json
+++ b/testdata/data/repos/standalone/StaleLiveCheck/StaleLiveEAPI/expected.json
@@ -1,0 +1,3 @@
+{"__class__": "StaleLiveEAPI", "category": "StaleLiveCheck", "package": "StaleLiveEAPI", "version": "2.9999", "old_eapi": 7, "new_eapi": 8}
+{"__class__": "StaleLiveEAPI", "category": "StaleLiveCheck", "package": "StaleLiveEAPI", "version": "3.9999", "old_eapi": 7, "new_eapi": 8}
+{"__class__": "StaleLiveEAPI", "category": "EclassUsageCheck", "package": "DuplicateEclassInherit", "version": "0", "old_eapi": 0, "new_eapi": 7}

--- a/testdata/repos/standalone/StaleLiveCheck/StaleLiveEAPI/StaleLiveEAPI-0.ebuild
+++ b/testdata/repos/standalone/StaleLiveCheck/StaleLiveEAPI/StaleLiveEAPI-0.ebuild
@@ -1,0 +1,6 @@
+EAPI=7
+
+DESCRIPTION="SLOT 0 is release only"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"

--- a/testdata/repos/standalone/StaleLiveCheck/StaleLiveEAPI/StaleLiveEAPI-1.9999.ebuild
+++ b/testdata/repos/standalone/StaleLiveCheck/StaleLiveEAPI/StaleLiveEAPI-1.9999.ebuild
@@ -1,0 +1,7 @@
+EAPI=8
+
+DESCRIPTION="SLOT 1 is fine"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="1"
+LICENSE="BSD"
+PROPERTIES="live"

--- a/testdata/repos/standalone/StaleLiveCheck/StaleLiveEAPI/StaleLiveEAPI-1.ebuild
+++ b/testdata/repos/standalone/StaleLiveCheck/StaleLiveEAPI/StaleLiveEAPI-1.ebuild
@@ -1,0 +1,6 @@
+EAPI=8
+
+DESCRIPTION="SLOT 1 is fine"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="1"
+LICENSE="BSD"

--- a/testdata/repos/standalone/StaleLiveCheck/StaleLiveEAPI/StaleLiveEAPI-2.1.ebuild
+++ b/testdata/repos/standalone/StaleLiveCheck/StaleLiveEAPI/StaleLiveEAPI-2.1.ebuild
@@ -1,0 +1,6 @@
+EAPI=8
+
+DESCRIPTION="SLOT 2 is not fine"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="2"
+LICENSE="BSD"

--- a/testdata/repos/standalone/StaleLiveCheck/StaleLiveEAPI/StaleLiveEAPI-2.9999.ebuild
+++ b/testdata/repos/standalone/StaleLiveCheck/StaleLiveEAPI/StaleLiveEAPI-2.9999.ebuild
@@ -1,0 +1,7 @@
+EAPI=7
+
+DESCRIPTION="SLOT 2 is not fine"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="2"
+LICENSE="BSD"
+PROPERTIES="live"

--- a/testdata/repos/standalone/StaleLiveCheck/StaleLiveEAPI/StaleLiveEAPI-2.ebuild
+++ b/testdata/repos/standalone/StaleLiveCheck/StaleLiveEAPI/StaleLiveEAPI-2.ebuild
@@ -1,0 +1,6 @@
+EAPI=7
+
+DESCRIPTION="SLOT 2 is not fine"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="2"
+LICENSE="BSD"

--- a/testdata/repos/standalone/StaleLiveCheck/StaleLiveEAPI/StaleLiveEAPI-3.1.ebuild
+++ b/testdata/repos/standalone/StaleLiveCheck/StaleLiveEAPI/StaleLiveEAPI-3.1.ebuild
@@ -1,0 +1,6 @@
+EAPI=7
+
+DESCRIPTION="SLOT 3 is not fine"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="3"
+LICENSE="BSD"

--- a/testdata/repos/standalone/StaleLiveCheck/StaleLiveEAPI/StaleLiveEAPI-3.9999.ebuild
+++ b/testdata/repos/standalone/StaleLiveCheck/StaleLiveEAPI/StaleLiveEAPI-3.9999.ebuild
@@ -1,0 +1,7 @@
+EAPI=7
+
+DESCRIPTION="SLOT 3 is not fine"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="3"
+LICENSE="BSD"
+PROPERTIES="live"

--- a/testdata/repos/standalone/StaleLiveCheck/StaleLiveEAPI/StaleLiveEAPI-3.ebuild
+++ b/testdata/repos/standalone/StaleLiveCheck/StaleLiveEAPI/StaleLiveEAPI-3.ebuild
@@ -1,0 +1,6 @@
+EAPI=8
+
+DESCRIPTION="SLOT 3 is not fine"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="3"
+LICENSE="BSD"

--- a/testdata/repos/standalone/StaleLiveCheck/StaleLiveEAPI/StaleLiveEAPI-4.9999.ebuild
+++ b/testdata/repos/standalone/StaleLiveCheck/StaleLiveEAPI/StaleLiveEAPI-4.9999.ebuild
@@ -1,0 +1,7 @@
+EAPI=8
+
+DESCRIPTION="SLOT 4 is live only"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="4"
+LICENSE="BSD"
+PROPERTIES="live"


### PR DESCRIPTION
<details><summary>Gentoo results</summary>

```
  app-arch/xz-utils
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  app-crypt/eid-mw
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  app-crypt/hashcat
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  app-i18n/libpinyin
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  app-misc/dateutils
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  app-misc/radeontop
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  app-misc/screen
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  app-text/pdftk
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  dev-libs/libevdev
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  dev-perl/App-cpanminus
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  dev-util/rocminfo
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  gui-apps/slurp
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  media-fonts/fontawesome
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  media-libs/libltc
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  net-im/prosody-modules
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  net-misc/apt-cacher-ng
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  sci-geosciences/gpsbabel
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  sci-geosciences/merkaartor
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  sys-apps/kexec-tools
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  sys-cluster/lmod
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  sys-devel/gcc
    StaleLiveEAPI: version 11.4.9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  sys-fs/zfs-auto-snapshot
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  sys-libs/musl
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  www-apps/icingaweb2-module-graphite
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  www-misc/profile-sync-daemon
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=6 than release ebuilds (EAPI=7)
  
  x11-misc/dmenu
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  x11-misc/nitrogen
    StaleLiveEAPI: version 99999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  x11-wm/i3
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
  
  x11-wm/lumina
    StaleLiveEAPI: version 9999: live ebuild uses older EAPI=7 than release ebuilds (EAPI=8)
```
</details>