### PR TITLE
new checks for deprecated manifest hashes

### DIFF
--- a/testdata/data/repos/standalone/ManifestCheck/DeprecatedManifestHash/expected.json
+++ b/testdata/data/repos/standalone/ManifestCheck/DeprecatedManifestHash/expected.json
@@ -1,0 +1,1 @@
+{"__class__": "DeprecatedManifestHash", "category": "ManifestCheck", "package": "MissingChksum", "hashes": ["rmd160", "sha1"]}

--- a/testdata/data/repos/standalone/RepoManifestHashCheck/DeprecatedRepoHash/expected.json
+++ b/testdata/data/repos/standalone/RepoManifestHashCheck/DeprecatedRepoHash/expected.json
@@ -1,0 +1,1 @@
+{"__class__": "DeprecatedRepoHash", "hashes": ["sha1", "whirlpool"]}

--- a/testdata/repos/standalone/metadata/layout.conf
+++ b/testdata/repos/standalone/metadata/layout.conf
@@ -5,3 +5,4 @@ eapis-banned = 1
 eapis-deprecated = 5
 properties-allowed = interactive live
 restrict-allowed = bindist fetch mirror test
+manifest-hashes = BLAKE2B SHA1 SHA512 WHIRLPOOL


### PR DESCRIPTION
2 new checks:

- `RepoManifestHashCheck`: check for deprecated repo config
- `DeprecatedManifestHash`: check for deprecated checksums in manifest files

Resolves: https://github.com/pkgcore/pkgcheck/issues/508