### PR TITLE
VariableScopeCheck: also check for wrong usage on global scope

### DIFF
--- a/testdata/data/repos/standalone/VariableScopeCheck/EbuildVariableScope/expected.json
+++ b/testdata/data/repos/standalone/VariableScopeCheck/EbuildVariableScope/expected.json
@@ -1,1 +1,2 @@
-{"__class__": "EbuildVariableScope", "category": "VariableScopeCheck", "package": "EbuildVariableScope", "version": "0", "variable": "EROOT", "func": "src_configure", "lines": [10]}
+{"__class__": "EbuildVariableScope", "category": "VariableScopeCheck", "package": "EbuildVariableScope", "version": "0", "lines": [12], "variable": "EROOT", "func": "src_configure"}
+{"__class__": "EbuildVariableScope", "category": "VariableScopeCheck", "package": "EbuildVariableScope", "version": "0", "lines": [8], "variable": "ROOT", "func": "global scope"}

--- a/testdata/data/repos/standalone/VariableScopeCheck/EbuildVariableScope/fix.patch
+++ b/testdata/data/repos/standalone/VariableScopeCheck/EbuildVariableScope/fix.patch
@@ -1,8 +1,12 @@
 diff -Naur standalone/VariableScopeCheck/EbuildVariableScope/EbuildVariableScope-0.ebuild fixed/VariableScopeCheck/EbuildVariableScope/EbuildVariableScope-0.ebuild
 --- standalone/VariableScopeCheck/EbuildVariableScope/EbuildVariableScope-0.ebuild	2021-03-17 01:20:05.423678951 -0600
 +++ fixed/VariableScopeCheck/EbuildVariableScope/EbuildVariableScope-0.ebuild	2021-03-17 01:21:57.421132212 -0600
-@@ -7,7 +7,7 @@
+@@ -5,11 +5,9 @@ HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+ SLOT="0"
+ LICENSE="BSD"
 
+-DOC_CONTENTS="Hello ${ROOT}"
+-
  src_configure() {
  	# EROOT isn't allowed in src_* phases
 -	econf --sysconfdir="${EROOT}/etc/${PN}"

--- a/testdata/repos/standalone/VariableScopeCheck/EbuildVariableScope/EbuildVariableScope-0.ebuild
+++ b/testdata/repos/standalone/VariableScopeCheck/EbuildVariableScope/EbuildVariableScope-0.ebuild
@@ -5,6 +5,8 @@ HOMEPAGE="https://github.com/pkgcore/pkgcheck"
 SLOT="0"
 LICENSE="BSD"
 
+DOC_CONTENTS="Hello ${ROOT}"
+
 src_configure() {
 	# EROOT isn't allowed in src_* phases
 	econf --sysconfdir="${EROOT}/etc/${PN}"


### PR DESCRIPTION
@ulm please verify I collected correctly all the variables from the table. I've taken all variables that have "consistent" value set to "no" in the table.

<details>
  <summary>Results excluding VERIFY_SIG_OPENPGP_KEY_PATH</summary>

  ```
  app-admin/conky
    VariableScope: version 1.17.0-r1: variable 'ROOT' used in 'global scope' on line: 110
    VariableScope: version 1.19.2-r1: variable 'ROOT' used in 'global scope' on line: 110
  
  app-mobilephone/adebar
    VariableScope: version 2.4.1: variable 'ROOT' used in 'global scope' on line: 26
  
  app-text/highlight
    VariableScope: version 4.1: variable 'D' used in 'global scope' on line: 46
    VariableScope: version 4.6: variable 'D' used in 'global scope' on line: 47
  
  dev-perl/Crypt-OpenSSL-Random
    VariableScope: version 0.150.0-r1: variable 'ESYSROOT' used in 'global scope' on line: 36
  
  dev-perl/Crypt-OpenSSL-RSA
    VariableScope: version 0.330.0: variable 'ESYSROOT' used in 'global scope' on line: 41
  
  dev-util/buildbot-worker
    VariableScope: version 3.6.1-r2: variable 'ROOT' used in 'global scope' on line: 44
    VariableScope: version 9999: variable 'ROOT' used in 'global scope' on line: 44
  
  games-action/descent3
    VariableScope: version 1.4.0b-r3: variable 'ED' used in 'global scope' on line: 30
  
  games-action/fakk2
    VariableScope: version 1.02-r1: variable 'D' used in 'global scope' on line: 22
  
  games-fps/soldieroffortune
    VariableScope: version 1.06a-r2: variable 'ED' used in 'global scope' on line: 32
  
  games-fps/tribes2
    VariableScope: version 25034: variable 'ED' used in 'global scope' on line: 31
  
  games-fps/transfusion-bin
    VariableScope: version 1.01-r1: variable 'D' used in 'global scope' on line: 35
  
  games-fps/ut2003-bonuspack-epic
    VariableScope: version 1-r1: variable 'ED' used in 'global scope' on line: 23
  
  games-fps/ut2003-demo
    VariableScope: version 2206-r5: variable 'ED' used in 'global scope' on line: 31
  
  games-fps/ut2003-data
    VariableScope: version 2107-r2: variable 'ED' used in 'global scope' on line: 25
  
  games-fps/ut2004-demo
    VariableScope: version 3334-r3: variable 'ED' used in 'global scope' on line: 28
  
  games-strategy/dominions2
    VariableScope: version 2.16-r1: variable 'ED' used in 'global scope' on line: 45
  
  games-strategy/majesty-demo
    VariableScope: version 1.0.0-r1: variable 'D' used in 'global scope' on line: 28
  
  media-radio/direwolf
    VariableScope: version 1.5-r1: variable 'D' used in 'global scope' on line: 28
  
  media-tv/plex-media-server
    VariableScope: version 1.31.1.6733: variable 'ED' used in 'global scope' on lines: 43, 44
    VariableScope: version 1.32.0.6973: variable 'ED' used in 'global scope' on lines: 44, 45
    VariableScope: version 1.32.1.6999: variable 'ED' used in 'global scope' on lines: 44, 45
    VariableScope: version 1.32.2.7100: variable 'ED' used in 'global scope' on lines: 44, 45
    VariableScope: version 1.32.3.7162: variable 'ED' used in 'global scope' on lines: 44, 45
  
  net-misc/asterisk
    VariableScope: version 16.29.1: variable 'D' used in 'global scope' on line: 117
    VariableScope: version 16.30.0: variable 'D' used in 'global scope' on line: 117
    VariableScope: version 18.15.1: variable 'D' used in 'global scope' on line: 115
    VariableScope: version 18.17.0: variable 'D' used in 'global scope' on line: 114
    VariableScope: version 18.17.1: variable 'D' used in 'global scope' on line: 115
    VariableScope: version 18.18.0: variable 'D' used in 'global scope' on line: 115
    VariableScope: version 20.3.0: variable 'D' used in 'global scope' on line: 114
  
  net-misc/radvd
    VariableScope: version 2.19-r2: variable 'ROOT' used in 'global scope' on lines: 60, 61
    VariableScope: version 2.19-r4: variable 'ROOT' used in 'global scope' on lines: 61, 62
  
  x11-misc/compose-tables
    VariableScope: version 1.8.6: variable 'ESYSROOT' used in 'global scope' on line: 30
  ```
</details>

<details>
  <summary>All Results</summary>

  ```
  app-admin/conky
    VariableScope: version 1.17.0-r1: variable 'ROOT' used in 'global scope' on line: 110
    VariableScope: version 1.19.2-r1: variable 'ROOT' used in 'global scope' on line: 110
  
  app-admin/logrotate
    VariableScope: version 3.20.1-r1: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 3.21.0: variable 'BROOT' used in 'global scope' on line: 6
  
  app-admin/stow
    VariableScope: version 2.3.1: variable 'BROOT' used in 'global scope' on line: 6
  
  app-admin/sudo
    VariableScope: version 1.9.13_p3-r1: variable 'BROOT' used in 'global scope' on line: 18
    VariableScope: version 1.9.14_p2: variable 'BROOT' used in 'global scope' on line: 18
    VariableScope: version 1.9.14_p3: variable 'BROOT' used in 'global scope' on line: 18
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 18
  
  app-antivirus/lkrg
    VariableScope: version 0.9.5: variable 'BROOT' used in 'global scope' on line: 20
    VariableScope: version 0.9.6: variable 'BROOT' used in 'global scope' on line: 20
    VariableScope: version 0.9.6-r1: variable 'BROOT' used in 'global scope' on line: 20
  
  app-arch/bzip2
    VariableScope: version 1.0.8-r4: variable 'BROOT' used in 'global scope' on line: 9
  
  app-arch/clzip
    VariableScope: version 1.13: variable 'BROOT' used in 'global scope' on line: 6
  
  app-arch/gzip
    VariableScope: version 1.12-r4: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 1.12_p20221228-r1: variable 'BROOT' used in 'global scope' on line: 6
  
  app-arch/lunzip
    VariableScope: version 1.13: variable 'BROOT' used in 'global scope' on line: 6
  
  app-arch/libarchive
    VariableScope: version 3.6.2-r1: variable 'BROOT' used in 'global scope' on line: 21
    VariableScope: version 3.7.0: variable 'BROOT' used in 'global scope' on line: 21
    VariableScope: version 3.7.1: variable 'BROOT' used in 'global scope' on line: 21
  
  app-arch/lziprecover
    VariableScope: version 1.23: variable 'BROOT' used in 'global scope' on line: 6
  
  app-arch/lzlib
    VariableScope: version 1.13-r1: variable 'BROOT' used in 'global scope' on line: 6
  
  app-arch/pdlzip
    VariableScope: version 1.12: variable 'BROOT' used in 'global scope' on line: 6
  
  app-arch/plzip
    VariableScope: version 1.10: variable 'BROOT' used in 'global scope' on line: 6
  
  app-arch/lzip
    VariableScope: version 1.23: variable 'BROOT' used in 'global scope' on line: 6
  
  app-arch/tar
    VariableScope: version 1.34-r2: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 1.34-r3: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 1.35: variable 'BROOT' used in 'global scope' on line: 6
  
  app-arch/xz-utils
    VariableScope: version 5.2.11: variable 'BROOT' used in 'global scope' on line: 18
    VariableScope: version 5.2.12: variable 'BROOT' used in 'global scope' on line: 18
    VariableScope: version 5.4.2: variable 'BROOT' used in 'global scope' on line: 23
    VariableScope: version 5.4.3: variable 'BROOT' used in 'global scope' on line: 23
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 23
  
  app-containers/distrobuilder
    VariableScope: version 2.1: variable 'BROOT' used in 'global scope' on line: 31
  
  app-containers/lxc-templates
    VariableScope: version 3.0.4: variable 'BROOT' used in 'global scope' on line: 25
  
  app-containers/lxc
    VariableScope: version 5.0.2: variable 'BROOT' used in 'global scope' on line: 66
    VariableScope: version 5.0.3: variable 'BROOT' used in 'global scope' on line: 66
  
  app-containers/lxd
    VariableScope: version 4.0.9-r3: variable 'BROOT' used in 'global scope' on line: 75
    VariableScope: version 5.0.2-r2: variable 'BROOT' used in 'global scope' on line: 75
  
  app-crypt/dehydrated
    VariableScope: version 0.7.1: variable 'BROOT' used in 'global scope' on line: 6
  
  app-crypt/gnupg
    VariableScope: version 2.2.41: variable 'BROOT' used in 'global scope' on line: 12
    VariableScope: version 2.4.2-r1: variable 'BROOT' used in 'global scope' on line: 12
    VariableScope: version 2.4.3: variable 'BROOT' used in 'global scope' on line: 12
  
  app-crypt/gpgme
    VariableScope: version 1.20.0: variable 'BROOT' used in 'global scope' on line: 15
    VariableScope: version 1.21.0: variable 'BROOT' used in 'global scope' on line: 15
  
  app-crypt/pinentry
    VariableScope: version 1.2.1-r3: variable 'BROOT' used in 'global scope' on line: 6
  
  app-crypt/sbctl
    VariableScope: version 0.11: variable 'BROOT' used in 'global scope' on line: 21
  
  app-crypt/signify
    VariableScope: version 31: variable 'BROOT' used in 'global scope' on line: 42
  
  app-crypt/yubikey-manager
    VariableScope: version 5.0.1: variable 'BROOT' used in 'global scope' on line: 28
    VariableScope: version 5.1.1: variable 'BROOT' used in 'global scope' on line: 28
  
  app-editors/vile
    VariableScope: version 9.8w-r1: variable 'BROOT' used in 'global scope' on line: 8
    VariableScope: version 9.8x: variable 'BROOT' used in 'global scope' on line: 8
    VariableScope: version 9.8y: variable 'BROOT' used in 'global scope' on line: 8
  
  app-editors/xvile
    VariableScope: version 9.8w-r2: variable 'BROOT' used in 'global scope' on line: 8
    VariableScope: version 9.8x: variable 'BROOT' used in 'global scope' on line: 8
    VariableScope: version 9.8y: variable 'BROOT' used in 'global scope' on line: 8
  
  app-emulation/libvirt
    VariableScope: version 9.3.0: variable 'BROOT' used in 'global scope' on line: 14
    VariableScope: version 9.4.0-r3: variable 'BROOT' used in 'global scope' on line: 14
    VariableScope: version 9.5.0: variable 'BROOT' used in 'global scope' on line: 14
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 14
  
  app-mobilephone/adebar
    VariableScope: version 2.4.1: variable 'ROOT' used in 'global scope' on line: 26
  
  app-office/libreoffice-voikko
    VariableScope: version 5.0-r1: variable 'BROOT' used in 'global scope' on line: 26
  
  app-shells/bash
    VariableScope: version 5.1_p16-r6: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 5.1_p16-r7: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 5.2_p15-r5: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 5.2_p15-r6: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 6
  
  app-text/highlight
    VariableScope: version 4.1: variable 'D' used in 'global scope' on line: 46
    VariableScope: version 4.6: variable 'D' used in 'global scope' on line: 47
  
  app-text/poppler
    VariableScope: version 23.05.0: variable 'BROOT' used in 'global scope' on line: 13
    VariableScope: version 23.07.0: variable 'BROOT' used in 'global scope' on line: 13
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 13
  
  app-text/xpdf
    VariableScope: version 4.04-r1: variable 'BROOT' used in 'global scope' on line: 6
  
  dev-java/batik
    VariableScope: version 1.16-r2: variable 'BROOT' used in 'global scope' on line: 45
  
  dev-java/bcel
    VariableScope: version 6.6.0: variable 'BROOT' used in 'global scope' on line: 52
  
  dev-java/commons-collections
    VariableScope: version 3.2.2-r1: variable 'BROOT' used in 'global scope' on line: 31
  
  dev-java/commons-daemon
    VariableScope: version 1.3.3: variable 'BROOT' used in 'global scope' on line: 28
  
  dev-java/commons-net
    VariableScope: version 3.9.0: variable 'BROOT' used in 'global scope' on line: 25
  
  dev-java/fop
    VariableScope: version 2.8-r1: variable 'BROOT' used in 'global scope' on line: 63
  
  dev-java/log4j-api
    VariableScope: version 2.19.0: variable 'BROOT' used in 'global scope' on line: 62
  
  dev-java/tomcat-native
    VariableScope: version 2.0.4: variable 'BROOT' used in 'global scope' on line: 33
  
  dev-java/xmlgraphics-commons
    VariableScope: version 2.8: variable 'BROOT' used in 'global scope' on line: 51
  
  dev-java/xz-java
    VariableScope: version 1.9-r1: variable 'BROOT' used in 'global scope' on line: 29
  
  dev-lang/python
    VariableScope: version 2.7.18_p16-r1: variable 'BROOT' used in 'global scope' on line: 80
    VariableScope: version 3.8.17: variable 'BROOT' used in 'global scope' on line: 83
    VariableScope: version 3.9.17: variable 'BROOT' used in 'global scope' on line: 84
    VariableScope: version 3.10.12: variable 'BROOT' used in 'global scope' on line: 88
    VariableScope: version 3.11.4: variable 'BROOT' used in 'global scope' on line: 93
    VariableScope: version 3.12.0_beta3: variable 'BROOT' used in 'global scope' on line: 98
    VariableScope: version 3.12.0_beta4: variable 'BROOT' used in 'global scope' on line: 98
    VariableScope: version 3.12.0_beta4_p1: variable 'BROOT' used in 'global scope' on line: 98
  
  dev-lang/rust-bin
    VariableScope: version 1.65.0-r1: variable 'BROOT' used in 'global scope' on line: 57
    VariableScope: version 1.66.1-r1: variable 'BROOT' used in 'global scope' on line: 57
    VariableScope: version 1.67.1-r3: variable 'BROOT' used in 'global scope' on line: 58
    VariableScope: version 1.68.2-r2: variable 'BROOT' used in 'global scope' on line: 55
    VariableScope: version 1.69.0-r1: variable 'BROOT' used in 'global scope' on line: 55
    VariableScope: version 1.70.0-r3: variable 'BROOT' used in 'global scope' on line: 59
    VariableScope: version 1.71.0: variable 'BROOT' used in 'global scope' on line: 59
  
  dev-lang/rust
    VariableScope: version 1.65.0: variable 'BROOT' used in 'global scope' on line: 164
    VariableScope: version 1.66.1: variable 'BROOT' used in 'global scope' on line: 162
    VariableScope: version 1.67.1-r1: variable 'BROOT' used in 'global scope' on line: 162
    VariableScope: version 1.68.2: variable 'BROOT' used in 'global scope' on line: 162
    VariableScope: version 1.69.0-r1: variable 'BROOT' used in 'global scope' on line: 162
    VariableScope: version 1.70.0: variable 'BROOT' used in 'global scope' on line: 162
    VariableScope: version 1.71.0: variable 'BROOT' used in 'global scope' on line: 162
  
  dev-libs/botan
    VariableScope: version 2.19.2: variable 'BROOT' used in 'global scope' on line: 7
    VariableScope: version 2.19.3-r2: variable 'BROOT' used in 'global scope' on line: 7
    VariableScope: version 3.0.0-r2: variable 'BROOT' used in 'global scope' on line: 7
    VariableScope: version 3.1.1: variable 'BROOT' used in 'global scope' on line: 7
  
  dev-libs/cdk
    VariableScope: version 5.0.20221025: variable 'BROOT' used in 'global scope' on line: 8
    VariableScope: version 5.0.20230201: variable 'BROOT' used in 'global scope' on line: 8
  
  dev-libs/crypto++
    VariableScope: version 8.6.0-r1: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 8.8.0: variable 'BROOT' used in 'global scope' on line: 6
  
  dev-libs/elfutils
    VariableScope: version 0.188: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 0.189-r1: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 0.189-r3: variable 'BROOT' used in 'global scope' on line: 6
  
  dev-libs/icu
    VariableScope: version 73.1-r2: variable 'BROOT' used in 'global scope' on line: 9
    VariableScope: version 73.2: variable 'BROOT' used in 'global scope' on line: 9
  
  dev-libs/icu-layoutex
    VariableScope: version 73.1: variable 'BROOT' used in 'global scope' on line: 7
    VariableScope: version 73.2: variable 'BROOT' used in 'global scope' on line: 7
  
  dev-libs/libassuan
    VariableScope: version 2.5.6: variable 'BROOT' used in 'global scope' on line: 12
  
  dev-libs/libbsd
    VariableScope: version 0.11.7: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 0.11.7-r2: variable 'BROOT' used in 'global scope' on line: 6
  
  dev-libs/libevent
    VariableScope: version 2.1.12-r1: variable 'BROOT' used in 'global scope' on line: 54
    VariableScope: version 2.2.1-r2: variable 'BROOT' used in 'global scope' on line: 50
  
  dev-libs/libgpg-error
    VariableScope: version 1.47: variable 'BROOT' used in 'global scope' on line: 12
  
  dev-libs/libgcrypt
    VariableScope: version 1.9.4-r2: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 1.10.1-r2: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 1.10.1-r3: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 1.10.2: variable 'BROOT' used in 'global scope' on line: 6
  
  dev-libs/libintl
    VariableScope: version 0.21.1: variable 'BROOT' used in 'global scope' on line: 9
    VariableScope: version 0.22-r1: variable 'BROOT' used in 'global scope' on line: 9
  
  dev-libs/libksba
    VariableScope: version 1.6.3: variable 'BROOT' used in 'global scope' on line: 12
    VariableScope: version 1.6.4: variable 'BROOT' used in 'global scope' on line: 12
  
  dev-libs/libpcre2
    VariableScope: version 10.42-r1: variable 'BROOT' used in 'global scope' on line: 6
  
  dev-libs/libsodium
    VariableScope: version 1.0.18_p20220618: variable 'BROOT' used in 'global scope' on line: 25
  
  dev-libs/libtasn1
    VariableScope: version 4.19.0: variable 'BROOT' used in 'global scope' on line: 6
  
  dev-libs/libvoikko
    VariableScope: version 4.3.2: variable 'BROOT' used in 'global scope' on line: 32
  
  dev-libs/mpfr
    VariableScope: version 4.2.0_p9: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 4.2.0_p12: variable 'BROOT' used in 'global scope' on line: 6
  
  dev-libs/nettle
    VariableScope: version 3.8.1: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 3.9: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 3.9.1: variable 'BROOT' used in 'global scope' on line: 6
  
  dev-libs/openssl-compat
    VariableScope: version 1.1.1u: variable 'BROOT' used in 'global scope' on line: 6
  
  dev-libs/openssl
    VariableScope: version 1.1.1u: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 3.0.9-r1: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 3.0.9-r2: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 3.1.1-r1: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 3.1.1-r2: variable 'BROOT' used in 'global scope' on line: 6
  
  dev-libs/voikko-fi
    VariableScope: version 2.5-r1: variable 'BROOT' used in 'global scope' on line: 27
  
  dev-libs/xalan-c
    VariableScope: version 1.12-r2: variable 'BROOT' used in 'global scope' on line: 22
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 22
  
  dev-perl/Crypt-OpenSSL-Random
    VariableScope: version 0.150.0-r1: variable 'ESYSROOT' used in 'global scope' on line: 36
  
  dev-perl/Crypt-OpenSSL-RSA
    VariableScope: version 0.330.0: variable 'ESYSROOT' used in 'global scope' on line: 41
  
  dev-python/django
    VariableScope: version 3.2.20: variable 'BROOT' used in 'global scope' on line: 64
    VariableScope: version 4.1.10: variable 'BROOT' used in 'global scope' on line: 61
    VariableScope: version 4.2.3: variable 'BROOT' used in 'global scope' on line: 61
    VariableScope: version 4.2.3-r1: variable 'BROOT' used in 'global scope' on line: 62
  
  dev-python/libvirt-python
    VariableScope: version 9.3.0: variable 'BROOT' used in 'global scope' on line: 47
    VariableScope: version 9.4.0: variable 'BROOT' used in 'global scope' on line: 47
    VariableScope: version 9.5.0: variable 'BROOT' used in 'global scope' on line: 47
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 47
  
  dev-python/miniupnpc
    VariableScope: version 2.2.4: variable 'BROOT' used in 'global scope' on line: 42
    VariableScope: version 2.2.5: variable 'BROOT' used in 'global scope' on line: 42
  
  dev-python/python-gnupg
    VariableScope: version 0.5.0: variable 'BROOT' used in 'global scope' on line: 8
    VariableScope: version 0.5.1: variable 'BROOT' used in 'global scope' on line: 8
  
  dev-python/python3-lxc
    VariableScope: version 3.0.4: variable 'BROOT' used in 'global scope' on line: 24
    VariableScope: version 3.0.4-r1: variable 'BROOT' used in 'global scope' on line: 26
  
  dev-util/bcpp
    VariableScope: version 20221002: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 20230130: variable 'BROOT' used in 'global scope' on line: 6
  
  dev-util/buildbot-worker
    VariableScope: version 3.6.1-r2: variable 'ROOT' used in 'global scope' on line: 44
    VariableScope: version 9999: variable 'ROOT' used in 'global scope' on line: 44
  
  dev-util/byacc
    VariableScope: version 20221229: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 20230201: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 20230219: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 20230521: variable 'BROOT' used in 'global scope' on line: 6
  
  dev-util/ccache
    VariableScope: version 4.7.4: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 4.8.2: variable 'BROOT' used in 'global scope' on line: 20
  
  dev-util/cproto
    VariableScope: version 4.7t-r1: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 4.7u-r1: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 4.7v: variable 'BROOT' used in 'global scope' on line: 6
  
  dev-util/cmake
    VariableScope: version 3.26.4-r1: variable 'BROOT' used in 'global scope' on line: 43
    VariableScope: version 3.26.5: variable 'BROOT' used in 'global scope' on line: 43
    VariableScope: version 3.27.0: variable 'BROOT' used in 'global scope' on line: 43
    VariableScope: version 3.27.1: variable 'BROOT' used in 'global scope' on line: 43
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 43
  
  dev-util/debugedit
    VariableScope: version 5.0-r1: variable 'BROOT' used in 'global scope' on line: 31
  
  dev-util/dialog
    VariableScope: version 1.3.20220728: variable 'BROOT' used in 'global scope' on line: 7
    VariableScope: version 1.3.20221229: variable 'BROOT' used in 'global scope' on line: 7
    VariableScope: version 1.3.20230209: variable 'BROOT' used in 'global scope' on line: 7
  
  dev-util/diffstat
    VariableScope: version 1.65: variable 'BROOT' used in 'global scope' on line: 6
  
  dev-util/valgrind
    VariableScope: version 3.20.0-r2: variable 'BROOT' used in 'global scope' on line: 14
    VariableScope: version 3.21.0-r1: variable 'BROOT' used in 'global scope' on line: 14
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 14
  
  games-action/descent3
    VariableScope: version 1.4.0b-r3: variable 'ED' used in 'global scope' on line: 30
  
  games-action/fakk2
    VariableScope: version 1.02-r1: variable 'D' used in 'global scope' on line: 22
  
  games-fps/soldieroffortune
    VariableScope: version 1.06a-r2: variable 'ED' used in 'global scope' on line: 32
  
  games-fps/transfusion-bin
    VariableScope: version 1.01-r1: variable 'D' used in 'global scope' on line: 35
  
  games-fps/tribes2
    VariableScope: version 25034: variable 'ED' used in 'global scope' on line: 31
  
  games-fps/ut2003-bonuspack-epic
    VariableScope: version 1-r1: variable 'ED' used in 'global scope' on line: 23
  
  games-fps/ut2003-demo
    VariableScope: version 2206-r5: variable 'ED' used in 'global scope' on line: 31
  
  games-fps/ut2003-data
    VariableScope: version 2107-r2: variable 'ED' used in 'global scope' on line: 25
  
  games-fps/ut2004-demo
    VariableScope: version 3334-r3: variable 'ED' used in 'global scope' on line: 28
  
  games-strategy/dominions2
    VariableScope: version 2.16-r1: variable 'ED' used in 'global scope' on line: 45
  
  games-strategy/majesty-demo
    VariableScope: version 1.0.0-r1: variable 'D' used in 'global scope' on line: 28
  
  mail-filter/spamassassin
    VariableScope: version 4.0.0-r3: variable 'BROOT' used in 'global scope' on line: 89
    VariableScope: version 4.0.0-r4: variable 'BROOT' used in 'global scope' on line: 89
  
  mail-mta/notqmail
    VariableScope: version 1.08-r6: variable 'BROOT' used in 'global scope' on line: 63
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 60
  
  media-gfx/graphicsmagick
    VariableScope: version 1.3.40: variable 'BROOT' used in 'global scope' on line: 16
    VariableScope: version 1.3.40-r1: variable 'BROOT' used in 'global scope' on line: 16
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 16
  
  media-gfx/renderdoc
    VariableScope: version 1.27: variable 'BROOT' used in 'global scope' on line: 108
  
  media-libs/libass
    VariableScope: version 0.16.0: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 0.17.1: variable 'BROOT' used in 'global scope' on line: 6
  
  media-libs/tiff-compat
    VariableScope: version 4.4.0-r1: variable 'BROOT' used in 'global scope' on line: 13
  
  media-libs/tiff
    VariableScope: version 4.5.0-r2: variable 'BROOT' used in 'global scope' on line: 13
    VariableScope: version 4.5.1: variable 'BROOT' used in 'global scope' on line: 13
  
  media-radio/direwolf
    VariableScope: version 1.5-r1: variable 'D' used in 'global scope' on line: 28
  
  media-tv/plex-media-server
    VariableScope: version 1.31.1.6733: variable 'ED' used in 'global scope' on lines: 43, 44
    VariableScope: version 1.32.0.6973: variable 'ED' used in 'global scope' on lines: 44, 45
    VariableScope: version 1.32.1.6999: variable 'ED' used in 'global scope' on lines: 44, 45
    VariableScope: version 1.32.2.7100: variable 'ED' used in 'global scope' on lines: 44, 45
    VariableScope: version 1.32.3.7162: variable 'ED' used in 'global scope' on lines: 44, 45
  
  media-video/ffmpeg
    VariableScope: version 4.4.4-r3: variable 'BROOT' used in 'global scope' on line: 33
    VariableScope: version 5.1.3-r3: variable 'BROOT' used in 'global scope' on line: 33
    VariableScope: version 6.0-r2: variable 'BROOT' used in 'global scope' on line: 33
    VariableScope: version 6.0-r5: variable 'BROOT' used in 'global scope' on line: 33
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 33
  
  net-analyzer/nmap
    VariableScope: version 7.92-r3: variable 'BROOT' used in 'global scope' on line: 17
    VariableScope: version 7.93-r3: variable 'BROOT' used in 'global scope' on line: 19
    VariableScope: version 7.94: variable 'BROOT' used in 'global scope' on line: 21
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 21
  
  net-analyzer/tcpdump
    VariableScope: version 4.99.4-r1: variable 'BROOT' used in 'global scope' on line: 16
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 16
  
  net-analyzer/suricata
    VariableScope: version 6.0.12: variable 'BROOT' used in 'global scope' on line: 20
    VariableScope: version 6.0.13: variable 'BROOT' used in 'global scope' on line: 20
  
  net-analyzer/tcpslice
    VariableScope: version 1.5: variable 'BROOT' used in 'global scope' on line: 21
  
  net-analyzer/vnstat
    VariableScope: version 2.10: variable 'BROOT' used in 'global scope' on line: 15
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 15
  
  net-dns/c-ares
    VariableScope: version 1.19.0: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 1.19.1: variable 'BROOT' used in 'global scope' on line: 6
  
  net-dns/libidn
    VariableScope: version 1.41: variable 'BROOT' used in 'global scope' on line: 6
  
  net-dns/knot-resolver
    VariableScope: version 5.6.0: variable 'BROOT' used in 'global scope' on line: 57
    VariableScope: version 5.6.0-r1: variable 'BROOT' used in 'global scope' on line: 57
  
  net-dns/libidn2
    VariableScope: version 2.3.4: variable 'BROOT' used in 'global scope' on line: 37
  
  net-firewall/conntrack-tools
    VariableScope: version 1.4.7-r1: variable 'BROOT' used in 'global scope' on line: 6
  
  net-dns/unbound
    VariableScope: version 1.16.3: variable 'BROOT' used in 'global scope' on line: 14
    VariableScope: version 1.17.0: variable 'BROOT' used in 'global scope' on line: 14
    VariableScope: version 1.17.1: variable 'BROOT' used in 'global scope' on line: 7
  
  net-firewall/nftables
    VariableScope: version 1.0.7-r1: variable 'BROOT' used in 'global scope' on line: 8
    VariableScope: version 1.0.8-r1: variable 'BROOT' used in 'global scope' on line: 9
    VariableScope: version 1.0.8-r2: variable 'BROOT' used in 'global scope' on line: 9
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 9
  
  net-irc/ngircd
    VariableScope: version 26.1-r5: variable 'BROOT' used in 'global scope' on line: 6
  
  net-irc/weechat
    VariableScope: version 3.8: variable 'BROOT' used in 'global scope' on line: 18
    VariableScope: version 4.0.2: variable 'BROOT' used in 'global scope' on line: 18
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 18
  
  net-irc/unrealircd
    VariableScope: version 5.2.4-r1: variable 'BROOT' used in 'global scope' on line: 7
    VariableScope: version 6.0.4.2: variable 'BROOT' used in 'global scope' on line: 7
  
  net-libs/gnutls
    VariableScope: version 3.7.6: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 3.7.7: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 3.7.8: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 3.7.9: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 3.8.0: variable 'BROOT' used in 'global scope' on line: 6
  
  net-libs/libmnl
    VariableScope: version 1.0.5: variable 'BROOT' used in 'global scope' on line: 6
  
  net-libs/libnetfilter_acct
    VariableScope: version 1.0.3: variable 'BROOT' used in 'global scope' on line: 17
  
  net-libs/libnetfilter_cthelper
    VariableScope: version 1.0.1-r1: variable 'BROOT' used in 'global scope' on line: 6
  
  net-libs/libnetfilter_cttimeout
    VariableScope: version 1.0.1: variable 'BROOT' used in 'global scope' on line: 6
  
  net-libs/libnetfilter_conntrack
    VariableScope: version 1.0.9: variable 'BROOT' used in 'global scope' on line: 16
    VariableScope: version 1.0.9-r1: variable 'BROOT' used in 'global scope' on line: 16
  
  net-libs/libnetfilter_queue
    VariableScope: version 1.0.5: variable 'BROOT' used in 'global scope' on line: 16
  
  net-libs/libnetfilter_log
    VariableScope: version 1.0.2: variable 'BROOT' used in 'global scope' on line: 17
  
  net-libs/libnfnetlink
    VariableScope: version 1.0.2: variable 'BROOT' used in 'global scope' on line: 6
  
  net-libs/libnftnl
    VariableScope: version 1.2.4: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 1.2.5: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 1.2.6: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 6
  
  net-libs/libpcap
    VariableScope: version 1.10.3: variable 'BROOT' used in 'global scope' on line: 15
    VariableScope: version 1.10.4: variable 'BROOT' used in 'global scope' on line: 15
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 15
  
  net-libs/miniupnpc
    VariableScope: version 2.2.4: variable 'BROOT' used in 'global scope' on line: 31
    VariableScope: version 2.2.5: variable 'BROOT' used in 'global scope' on line: 31
  
  net-misc/asterisk
    VariableScope: version 16.29.1: variable 'D' used in 'global scope' on line: 117
    VariableScope: version 16.30.0: variable 'D' used in 'global scope' on line: 117
    VariableScope: version 18.15.1: variable 'D' used in 'global scope' on line: 115
    VariableScope: version 18.17.0: variable 'D' used in 'global scope' on line: 114
    VariableScope: version 18.17.1: variable 'D' used in 'global scope' on line: 115
    VariableScope: version 18.18.0: variable 'D' used in 'global scope' on line: 115
    VariableScope: version 20.3.0: variable 'D' used in 'global scope' on line: 114
  
  net-misc/chrony
    VariableScope: version 4.3-r2: variable 'BROOT' used in 'global scope' on line: 15
    VariableScope: version 4.3-r5: variable 'BROOT' used in 'global scope' on line: 15
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 15
  
  net-misc/curl
    VariableScope: version 8.0.1: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 8.1.2: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 8.2.1: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 6
  
  net-misc/dropbear
    VariableScope: version 2022.83: variable 'BROOT' used in 'global scope' on line: 7
  
  net-misc/minissdpd
    VariableScope: version 1.5.20211105: variable 'BROOT' used in 'global scope' on line: 36
    VariableScope: version 1.6.0: variable 'BROOT' used in 'global scope' on line: 36
  
  net-misc/miniupnpd
    VariableScope: version 2.3.1: variable 'BROOT' used in 'global scope' on line: 50
    VariableScope: version 2.3.2: variable 'BROOT' used in 'global scope' on line: 50
    VariableScope: version 2.3.3: variable 'BROOT' used in 'global scope' on line: 50
  
  net-misc/openssh
    VariableScope: version 9.3_p1-r1: variable 'BROOT' used in 'global scope' on line: 17
    VariableScope: version 9.3_p2: variable 'BROOT' used in 'global scope' on line: 17
  
  net-misc/openssh-contrib
    VariableScope: version 9.3_p1: variable 'BROOT' used in 'global scope' on line: 49
    VariableScope: version 9.3_p2: variable 'BROOT' used in 'global scope' on line: 45
  
  net-misc/radvd
    VariableScope: version 2.19-r2: variable 'ROOT' used in 'global scope' on lines: 60, 61
    VariableScope: version 2.19-r4: variable 'ROOT' used in 'global scope' on lines: 61, 62
  
  net-misc/rsync
    VariableScope: version 3.2.4-r3: variable 'BROOT' used in 'global scope' on line: 24
    VariableScope: version 3.2.7-r2: variable 'BROOT' used in 'global scope' on line: 19
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 19
  
  net-misc/turbovnc
    VariableScope: version 3.0.3: variable 'BROOT' used in 'global scope' on line: 74
  
  net-misc/wget
    VariableScope: version 1.21.3-r1: variable 'BROOT' used in 'global scope' on line: 7
    VariableScope: version 1.21.4: variable 'BROOT' used in 'global scope' on line: 7
  
  net-p2p/freenet
    VariableScope: version 0.7.5_p1497: variable 'BROOT' used in 'global scope' on line: 96
  
  net-p2p/ncdc
    VariableScope: version 1.23.1: variable 'BROOT' used in 'global scope' on line: 37
  
  net-vpn/ocserv
    VariableScope: version 1.1.6: variable 'BROOT' used in 'global scope' on line: 13
    VariableScope: version 1.1.7: variable 'BROOT' used in 'global scope' on line: 13
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 13
  
  net-vpn/openconnect
    VariableScope: version 9.12: variable 'BROOT' used in 'global scope' on line: 75
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 75
  
  net-vpn/tor
    VariableScope: version 0.4.7.13-r1: variable 'BROOT' used in 'global scope' on line: 7
    VariableScope: version 0.4.7.14: variable 'BROOT' used in 'global scope' on line: 7
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 7
  
  sci-astronomy/stellarium
    VariableScope: version 23.1: variable 'BROOT' used in 'global scope' on line: 105
    VariableScope: version 23.2: variable 'BROOT' used in 'global scope' on line: 105
  
  sci-libs/dealii
    VariableScope: version 9.4.0-r1: variable 'BROOT' used in 'global scope' on line: 87
    VariableScope: version 9.4.1-r1: variable 'BROOT' used in 'global scope' on line: 87
  
  sec-keys/signify-keys-signify
    VariableScope: version 30: variable 'BROOT' used in 'global scope' on line: 25
  
  sys-apps/coreutils
    VariableScope: version 9.1-r2: variable 'BROOT' used in 'global scope' on line: 11
    VariableScope: version 9.3-r2: variable 'BROOT' used in 'global scope' on line: 13
    VariableScope: version 9.3-r3: variable 'BROOT' used in 'global scope' on line: 13
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 13
  
  sys-apps/diffutils
    VariableScope: version 3.8: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 3.9: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 3.9-r1: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 3.10: variable 'BROOT' used in 'global scope' on line: 6
  
  sys-apps/ed
    VariableScope: version 1.18: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 1.19-r1: variable 'BROOT' used in 'global scope' on line: 6
  
  sys-apps/findutils
    VariableScope: version 4.9.0-r2: variable 'BROOT' used in 'global scope' on line: 7
  
  sys-apps/file
    VariableScope: version 5.44-r3: variable 'BROOT' used in 'global scope' on line: 16
    VariableScope: version 5.45: variable 'BROOT' used in 'global scope' on line: 16
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 16
  
  sys-apps/gawk
    VariableScope: version 5.2.1: variable 'BROOT' used in 'global scope' on line: 26
    VariableScope: version 5.2.2: variable 'BROOT' used in 'global scope' on line: 26
  
  sys-apps/grep
    VariableScope: version 3.7: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 3.8-r1: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 3.11: variable 'BROOT' used in 'global scope' on line: 6
  
  sys-apps/mawk
    VariableScope: version 1.3.4_p20230322: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 1.3.4_p20230404: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 1.3.4_p20230525: variable 'BROOT' used in 'global scope' on line: 6
  
  sys-apps/sed
    VariableScope: version 4.9: variable 'BROOT' used in 'global scope' on line: 6
  
  sys-apps/shadow
    VariableScope: version 4.13-r3: variable 'BROOT' used in 'global scope' on line: 10
    VariableScope: version 4.13-r4: variable 'BROOT' used in 'global scope' on line: 10
  
  sys-apps/sysvinit
    VariableScope: version 3.07: variable 'BROOT' used in 'global scope' on line: 9
    VariableScope: version 3.07-r1: variable 'BROOT' used in 'global scope' on line: 9
  
  sys-apps/util-linux
    VariableScope: version 2.38.1-r2: variable 'BROOT' used in 'global scope' on line: 18
    VariableScope: version 2.39.1: variable 'BROOT' used in 'global scope' on line: 18
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 18
  
  sys-block/parted
    VariableScope: version 3.6: variable 'BROOT' used in 'global scope' on line: 6
  
  sys-boot/grub
    VariableScope: version 2.06-r7: variable 'BROOT' used in 'global scope' on line: 28
    VariableScope: version 2.12_rc1-r1: variable 'BROOT' used in 'global scope' on line: 26
  
  sys-devel/autoconf-dickey
    VariableScope: version 2.52_p20221202: variable 'BROOT' used in 'global scope' on line: 9
    VariableScope: version 2.52_p20230114: variable 'BROOT' used in 'global scope' on line: 9
  
  sys-devel/bison
    VariableScope: version 3.8.2-r2: variable 'BROOT' used in 'global scope' on line: 6
  
  sys-devel/gettext
    VariableScope: version 0.21.1: variable 'BROOT' used in 'global scope' on line: 8
    VariableScope: version 0.22-r1: variable 'BROOT' used in 'global scope' on line: 8
  
  sys-devel/m4
    VariableScope: version 1.4.19-r2: variable 'BROOT' used in 'global scope' on line: 6
  
  sys-devel/make
    VariableScope: version 4.3-r1: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 4.4.1-r1: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 6
  
  sys-devel/patch
    VariableScope: version 2.7.6-r4: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 2.7.6-r5: variable 'BROOT' used in 'global scope' on line: 6
  
  sys-devel/reflex
    VariableScope: version 20221012: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 20230206: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 20230521: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 20230523: variable 'BROOT' used in 'global scope' on line: 6
  
  sys-devel/slibtool
    VariableScope: version 0.5.34: variable 'BROOT' used in 'global scope' on line: 15
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 15
  
  sys-fs/lxcfs
    VariableScope: version 5.0.3: variable 'BROOT' used in 'global scope' on line: 32
    VariableScope: version 5.0.4: variable 'BROOT' used in 'global scope' on line: 33
  
  sys-fs/ncdu-bin
    VariableScope: version 2.2.1: variable 'BROOT' used in 'global scope' on line: 30
  
  sys-fs/ncdu
    VariableScope: version 1.18: variable 'BROOT' used in 'global scope' on line: 27
    VariableScope: version 1.18.1: variable 'BROOT' used in 'global scope' on line: 27
    VariableScope: version 2.2.2-r1: variable 'BROOT' used in 'global scope' on line: 31
  
  sys-fs/zfs-kmod
    VariableScope: version 2.1.9: variable 'BROOT' used in 'global scope' on line: 15
    VariableScope: version 2.1.11: variable 'BROOT' used in 'global scope' on line: 15
    VariableScope: version 2.1.11-r1: variable 'BROOT' used in 'global scope' on line: 19
    VariableScope: version 2.1.12: variable 'BROOT' used in 'global scope' on line: 19
    VariableScope: version 2.2.0_rc3: variable 'BROOT' used in 'global scope' on line: 19
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 19
  
  sys-fs/zfs
    VariableScope: version 2.1.9: variable 'BROOT' used in 'global scope' on line: 18
    VariableScope: version 2.1.11: variable 'BROOT' used in 'global scope' on line: 18
    VariableScope: version 2.1.12: variable 'BROOT' used in 'global scope' on line: 19
    VariableScope: version 2.2.0_rc3: variable 'BROOT' used in 'global scope' on line: 19
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 19
  
  sys-kernel/vanilla-kernel
    VariableScope: version 5.4.250: variable 'BROOT' used in 'global scope' on line: 57
    VariableScope: version 5.4.251: variable 'BROOT' used in 'global scope' on line: 57
    VariableScope: version 5.10.187: variable 'BROOT' used in 'global scope' on line: 58
    VariableScope: version 5.10.188: variable 'BROOT' used in 'global scope' on line: 58
    VariableScope: version 5.15.122: variable 'BROOT' used in 'global scope' on line: 58
    VariableScope: version 5.15.123: variable 'BROOT' used in 'global scope' on line: 58
    VariableScope: version 6.1.41: variable 'BROOT' used in 'global scope' on line: 58
    VariableScope: version 6.1.42: variable 'BROOT' used in 'global scope' on line: 58
    VariableScope: version 6.4.6: variable 'BROOT' used in 'global scope' on line: 58
    VariableScope: version 6.4.7: variable 'BROOT' used in 'global scope' on line: 58
  
  sys-libs/gdbm
    VariableScope: version 1.23: variable 'BROOT' used in 'global scope' on line: 6
  
  sys-libs/musl
    VariableScope: version 1.2.3: variable 'BROOT' used in 'global scope' on line: 11
    VariableScope: version 1.2.3-r7: variable 'BROOT' used in 'global scope' on line: 11
    VariableScope: version 1.2.3-r8: variable 'BROOT' used in 'global scope' on line: 11
    VariableScope: version 1.2.4: variable 'BROOT' used in 'global scope' on line: 11
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 11
  
  sys-libs/ncurses-compat
    VariableScope: version 6.4_p20230401: variable 'BROOT' used in 'global scope' on line: 10
  
  sys-libs/ncurses
    VariableScope: version 6.4_p20230401: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 6.4_p20230527: variable 'BROOT' used in 'global scope' on line: 9
  
  sys-libs/readline
    VariableScope: version 8.1_p2-r1: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 8.2_p1: variable 'BROOT' used in 'global scope' on line: 10
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 10
  
  sys-libs/zlib
    VariableScope: version 1.2.13-r1: variable 'BROOT' used in 'global scope' on line: 8
  
  sys-process/parallel
    VariableScope: version 20230522: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 20230622: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 20230722: variable 'BROOT' used in 'global scope' on line: 6
  
  www-client/lynx
    VariableScope: version 2.9.0_pre10: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 2.9.0_pre11: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 2.9.0_pre12-r1: variable 'BROOT' used in 'global scope' on line: 6
  
  www-servers/tomcat
    VariableScope: version 8.5.90: variable 'BROOT' used in 'global scope' on line: 48
    VariableScope: version 8.5.91: variable 'BROOT' used in 'global scope' on line: 48
    VariableScope: version 9.0.76: variable 'BROOT' used in 'global scope' on line: 52
    VariableScope: version 9.0.78: variable 'BROOT' used in 'global scope' on line: 52
    VariableScope: version 10.1.10: variable 'BROOT' used in 'global scope' on line: 50
    VariableScope: version 10.1.11: variable 'BROOT' used in 'global scope' on line: 50
  
  x11-apps/luit
    VariableScope: version 20221028: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 20230201: variable 'BROOT' used in 'global scope' on line: 6
  
  x11-misc/compose-tables
    VariableScope: version 1.8.6: variable 'ESYSROOT' used in 'global scope' on line: 30
  
  x11-terms/kitty
    VariableScope: version 0.27.1: variable 'BROOT' used in 'global scope' on line: 18
    VariableScope: version 0.29.1: variable 'BROOT' used in 'global scope' on line: 18
    VariableScope: version 0.29.2: variable 'BROOT' used in 'global scope' on line: 18
    VariableScope: version 9999: variable 'BROOT' used in 'global scope' on line: 19
  
  x11-terms/terminator
    VariableScope: version 2.1.2: variable 'BROOT' used in 'global scope' on line: 43
    VariableScope: version 2.1.3: variable 'BROOT' used in 'global scope' on line: 43
  
  x11-terms/xterm
    VariableScope: version 379: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 380: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 381: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 382: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 383: variable 'BROOT' used in 'global scope' on line: 6
    VariableScope: version 384: variable 'BROOT' used in 'global scope' on line: 6
  ```
</details>

Resolves: https://github.com/pkgcore/pkgcheck/issues/606