### PR TITLE
GlobDistdir: check for glob usage with DISTDIR

### DIFF
--- a/testdata/data/repos/standalone/GlobCheck/GlobDistdir/expected.json
+++ b/testdata/data/repos/standalone/GlobCheck/GlobDistdir/expected.json
@@ -1,0 +1,3 @@
+{"__class__": "GlobDistdir", "category": "GlobCheck", "package": "GlobDistdir", "version": "0", "line": "\"${DISTDIR}\"/foo-*.bar", "lineno": 7}
+{"__class__": "GlobDistdir", "category": "GlobCheck", "package": "GlobDistdir", "version": "0", "line": "\"${DISTDIR}\"/\"${DISTDIR}\"/foo-?.bar", "lineno": 8}
+{"__class__": "GlobDistdir", "category": "GlobCheck", "package": "GlobDistdir", "version": "0", "line": "\"${DISTDIR}\"/foo-?-*.bar", "lineno": 9}

--- a/testdata/repos/standalone/GlobCheck/GlobDistdir/GlobDistdir-0.ebuild
+++ b/testdata/repos/standalone/GlobCheck/GlobDistdir/GlobDistdir-0.ebuild
@@ -1,0 +1,15 @@
+DESCRIPTION="Ebuild with unsafe glob around DISTDIR"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"
+
+src_install() {
+	doins "${DISTDIR}"/foo-*.bar # bad
+	doins "${DISTDIR}"/"${DISTDIR}"/foo-?.bar # bad
+	doins "${DISTDIR}"/foo-?-*.bar # bad
+
+	doins "${T}"/foo-*.bar # not unsafe dir
+	doins "${DISTDIR}"/foo-1.bar # no glob
+	doins "${DISTDIR}"/"foo-*.bar" # quoted
+	doins "${DISTDIR}"/'foo-*.bar' # quoted
+}


### PR DESCRIPTION
This time I decided to try to implement using tree-sitter query language. It is faster than in python scan, which is nice.

```
$ pkgcheck scan -c GlobCheck
games-strategy/homm2-gold-gog
  GlobDistdir: version 1.1.2.1.33438: line 40: unsafe filename expansion used with DISTDIR: "${DISTDIR}"/setup_heroes*.exe

media-gfx/darktable
  GlobDistdir: version 4.2.1: line 174: unsafe filename expansion used with DISTDIR: "${DISTDIR}"/${PN}-usermanual-${DOC_PV}.*.pdf
  GlobDistdir: version 4.4.1: line 171: unsafe filename expansion used with DISTDIR: "${DISTDIR}"/${PN}-usermanual-${DOC_PV}.*.pdf
  GlobDistdir: version 4.4.2: line 171: unsafe filename expansion used with DISTDIR: "${DISTDIR}"/${PN}-usermanual-${DOC_PV}.*.pdf
```

Resolves: https://github.com/pkgcore/pkgcheck/issues/605