### PR TITLE
EclassManualDepsCheck: add check for missing manual deps

### DIFF
--- a/testdata/data/repos/standalone/EclassManualDepsCheck/GoMissingDeps/expected.json
+++ b/testdata/data/repos/standalone/EclassManualDepsCheck/GoMissingDeps/expected.json
@@ -1,0 +1,1 @@
+{"__class__": "GoMissingDeps", "category": "EclassUsageCheck", "package": "DeprecatedEclassVariable", "version": "0"}

--- a/testdata/data/repos/standalone/EclassManualDepsCheck/RubyMissingDeps/expected.json
+++ b/testdata/data/repos/standalone/EclassManualDepsCheck/RubyMissingDeps/expected.json
@@ -1,0 +1,1 @@
+{"__class__": "RubyMissingDeps", "category": "EclassManualDepsCheck", "package": "RubyMissingDeps", "version": "1"}

--- a/testdata/data/repos/standalone/EclassManualDepsCheck/RubyMissingDeps/fix.patch
+++ b/testdata/data/repos/standalone/EclassManualDepsCheck/RubyMissingDeps/fix.patch
@@ -1,0 +1,9 @@
+diff -Naur standalone/EclassManualDepsCheck/RubyMissingDeps/RubyMissingDeps-1.ebuild fixed/EclassManualDepsCheck/RubyMissingDeps/RubyMissingDeps-1.ebuild
+--- standalone/EclassManualDepsCheck/RubyMissingDeps/RubyMissingDeps-1.ebuild
++++ fixed/EclassManualDepsCheck/RubyMissingDeps/RubyMissingDeps-1.ebuild
+@@ -6,3 +6,5 @@ DESCRIPTION="Optional inherit without dep"
+ HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+ SLOT="0"
+ LICENSE="BSD"
++
++DEPEND="virtual/rubygems"

--- a/testdata/data/repos/standalone/EclassManualDepsCheck/RustMissingDeps/expected.json
+++ b/testdata/data/repos/standalone/EclassManualDepsCheck/RustMissingDeps/expected.json
@@ -1,0 +1,1 @@
+{"__class__": "RustMissingDeps", "category": "EclassManualDepsCheck", "package": "RustMissingDeps", "version": "1"}

--- a/testdata/data/repos/standalone/EclassManualDepsCheck/RustMissingDeps/fix.patch
+++ b/testdata/data/repos/standalone/EclassManualDepsCheck/RustMissingDeps/fix.patch
@@ -1,0 +1,9 @@
+diff -Naur standalone/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-1.ebuild fixed/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-1.ebuild
+--- standalone/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-1.ebuild
++++ fixed/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-1.ebuild
+@@ -8,3 +8,5 @@ DESCRIPTION="Optional inherit without deps"
+ HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+ SLOT="0"
+ LICENSE="BSD"
++
++BDEPEND="virtual/rust"

--- a/testdata/repos/standalone/EclassManualDepsCheck/RubyMissingDeps/RubyMissingDeps-0.ebuild
+++ b/testdata/repos/standalone/EclassManualDepsCheck/RubyMissingDeps/RubyMissingDeps-0.ebuild
@@ -1,0 +1,12 @@
+EAPI=8
+
+RUBY_OPTIONAL=1
+
+inherit ruby-ng
+
+DESCRIPTION="Optional inherit with one dep"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"
+
+IDEPEND="dev-lang/ruby"

--- a/testdata/repos/standalone/EclassManualDepsCheck/RubyMissingDeps/RubyMissingDeps-1.ebuild
+++ b/testdata/repos/standalone/EclassManualDepsCheck/RubyMissingDeps/RubyMissingDeps-1.ebuild
@@ -1,0 +1,8 @@
+RUBY_OPTIONAL=1
+
+inherit ruby-ng
+
+DESCRIPTION="Optional inherit without dep"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"

--- a/testdata/repos/standalone/EclassManualDepsCheck/RubyMissingDeps/RubyMissingDeps-2.ebuild
+++ b/testdata/repos/standalone/EclassManualDepsCheck/RubyMissingDeps/RubyMissingDeps-2.ebuild
@@ -1,0 +1,14 @@
+EAPI=8
+
+RUBY_OPTIONAL=1
+
+inherit ruby-ng
+
+DESCRIPTION="Optional inherit with category whitelist"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"
+
+IUSE="test"
+RESTRICT="!test? ( test )"
+BDEPEND="test? ( dev-ruby/stub )"

--- a/testdata/repos/standalone/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-0.ebuild
+++ b/testdata/repos/standalone/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-0.ebuild
@@ -1,0 +1,6 @@
+inherit cargo
+
+DESCRIPTION="Normal non-optional inherit"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"

--- a/testdata/repos/standalone/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-1.ebuild
+++ b/testdata/repos/standalone/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-1.ebuild
@@ -1,0 +1,10 @@
+EAPI=7
+
+CARGO_OPTIONAL=1
+
+inherit cargo
+
+DESCRIPTION="Optional inherit without deps"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"

--- a/testdata/repos/standalone/dev-lang/ruby/ruby-0.ebuild
+++ b/testdata/repos/standalone/dev-lang/ruby/ruby-0.ebuild
@@ -1,0 +1,4 @@
+DESCRIPTION="Stub ebuild"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"

--- a/testdata/repos/standalone/dev-ruby/stub/stub-0.ebuild
+++ b/testdata/repos/standalone/dev-ruby/stub/stub-0.ebuild
@@ -1,0 +1,4 @@
+DESCRIPTION="Stub ebuild"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"

--- a/testdata/repos/standalone/eclass/ruby-ng.eclass
+++ b/testdata/repos/standalone/eclass/ruby-ng.eclass
@@ -1,0 +1,1 @@
+# ruby-ng eclass

--- a/testdata/repos/standalone/virtual/rubygems/rubygems-0.ebuild
+++ b/testdata/repos/standalone/virtual/rubygems/rubygems-0.ebuild
@@ -1,0 +1,2 @@
+DESCRIPTION="Stub ebuild"
+SLOT="0"

--- a/testdata/repos/standalone/virtual/rust/rust-0.ebuild
+++ b/testdata/repos/standalone/virtual/rust/rust-0.ebuild
@@ -1,0 +1,2 @@
+DESCRIPTION="Stub ebuild"
+SLOT="0"


### PR DESCRIPTION
Whn in special modes of eclasses (for example CARGO_OPTIONAL=1), verify specific dependencies are listed somehow in one of the dependencies var.

For commit https://github.com/gentoo/gentoo/commit/2a8a35c8cf88eb696e9ad08e22103b0e94397e7b, I get those results:

```
dev-python/cryptography
  RustMissingDeps: version 41.0.3: sets CARGO_OPTIONAL but does not depend on virtual/rust

sys-apps/portage
  TmpfilesMissingDeps: version 3.0.45.3-r2: sets TMPFILES_OPTIONAL but does not depend on virtual/tmpfiles
  TmpfilesMissingDeps: version 3.0.46: sets TMPFILES_OPTIONAL but does not depend on virtual/tmpfiles
  TmpfilesMissingDeps: version 3.0.49-r2: sets TMPFILES_OPTIONAL but does not depend on virtual/tmpfiles
  TmpfilesMissingDeps: version 3.0.50: sets TMPFILES_OPTIONAL but does not depend on virtual/tmpfiles
  TmpfilesMissingDeps: version 3.0.51: sets TMPFILES_OPTIONAL but does not depend on virtual/tmpfiles
  TmpfilesMissingDeps: version 9999: sets TMPFILES_OPTIONAL but does not depend on virtual/tmpfiles

sys-libs/glibc
  TmpfilesMissingDeps: version 2.19-r2: sets TMPFILES_OPTIONAL but does not depend on virtual/tmpfiles
  TmpfilesMissingDeps: version 2.31-r7: sets TMPFILES_OPTIONAL but does not depend on virtual/tmpfiles
  TmpfilesMissingDeps: version 2.32-r8: sets TMPFILES_OPTIONAL but does not depend on virtual/tmpfiles
  TmpfilesMissingDeps: version 2.33-r14: sets TMPFILES_OPTIONAL but does not depend on virtual/tmpfiles
  TmpfilesMissingDeps: version 2.34-r14: sets TMPFILES_OPTIONAL but does not depend on virtual/tmpfiles
  TmpfilesMissingDeps: version 2.35-r11: sets TMPFILES_OPTIONAL but does not depend on virtual/tmpfiles
  TmpfilesMissingDeps: version 2.36-r8: sets TMPFILES_OPTIONAL but does not depend on virtual/tmpfiles
  TmpfilesMissingDeps: version 2.37-r3: sets TMPFILES_OPTIONAL but does not depend on virtual/tmpfiles
  TmpfilesMissingDeps: version 2.37-r4: sets TMPFILES_OPTIONAL but does not depend on virtual/tmpfiles
  TmpfilesMissingDeps: version 2.38-r1: sets TMPFILES_OPTIONAL but does not depend on virtual/tmpfiles
  TmpfilesMissingDeps: version 9999: sets TMPFILES_OPTIONAL but does not depend on virtual/tmpfiles
```

Resolves: https://github.com/pkgcore/pkgcheck/issues/615

## TODO:

- [x] add tests