### PR TITLE
addons: git: pass --no-find-copies --no-find-copies-harder --find-ren…

### DIFF
--- a/src/pkgcheck/addons/git.py
+++ b/src/pkgcheck/addons/git.py
@@ -155,6 +155,7 @@ class _ParseGitRepo:
         cmd = shlex.split(self._git_cmd)
         cmd.append(f"--pretty=tformat:%n{'%n'.join(self._format)}")
         cmd.append(commit_range)
+        cmd.extend(("--no-find-copies", "--no-find-copies-harder", "--find-renames"))
 
         self.git_log = GitLog(cmd, self.path)
         # discard the initial newline


### PR DESCRIPTION
…ames to git log

I currently have a local git hack to allow configuring git to default to --find-copies-harder because it's *extremely* useful when working on ebuild repositories (prompted by a discussion with Eli Schwartz).

Unfortunately, this can confuse pkgcheck's git intergration because it'll call `git log` like:
```
git log --name-status --diff-filter=ARMD -z --pretty=tformat:%n%h%n%ct cc5b3b9f134a070c548faa4e3de17d615497d0b3..origin/HEAD
```
and get nothing back because (I think) git is interpreting some changes as copies rather than renames or new files.

Explicitly pass options to disable finding copies, even though normally this isn't necessary, to keep things working.