### PR TITLE
DeclarationShadowedCheck: new checks to detect shadowed variables & functions

### DIFF
--- a/testdata/data/repos/standalone/DeclarationShadowedCheck/DuplicateFunctionDefinition/expected.json
+++ b/testdata/data/repos/standalone/DeclarationShadowedCheck/DuplicateFunctionDefinition/expected.json
@@ -1,0 +1,2 @@
+{"__class__": "DuplicateFunctionDefinition", "category": "DeclarationShadowedCheck", "package": "DuplicateFunctionDefinition", "version": "0", "lines": [11, 15], "func_name": "any_function"}
+{"__class__": "DuplicateFunctionDefinition", "category": "DeclarationShadowedCheck", "package": "DuplicateFunctionDefinition", "version": "0", "lines": [7, 19], "func_name": "pkg_preinst"}

--- a/testdata/data/repos/standalone/DeclarationShadowedCheck/VariableShadowed/expected.json
+++ b/testdata/data/repos/standalone/DeclarationShadowedCheck/VariableShadowed/expected.json
@@ -1,0 +1,3 @@
+{"__class__": "VariableShadowed", "category": "DeclarationShadowedCheck", "package": "VariableShadowed", "version": "0", "lines": [11, 13], "var_name": "RDEPEND"}
+{"__class__": "VariableShadowed", "category": "DeclarationShadowedCheck", "package": "VariableShadowed", "version": "0", "lines": [9, 15], "var_name": "RESTRICT"}
+{"__class__": "VariableShadowed", "category": "DeclarationShadowedCheck", "package": "VariableShadowed", "version": "0", "lines": [5, 16], "var_name": "VAL"}

--- a/testdata/data/repos/standalone/DeclarationShadowedCheck/VariableShadowed/fix.patch
+++ b/testdata/data/repos/standalone/DeclarationShadowedCheck/VariableShadowed/fix.patch
@@ -1,0 +1,21 @@
+diff -Naur standalone/DeclarationShadowedCheck/VariableShadowed/VariableShadowed-0.ebuild fixed/DeclarationShadowedCheck/VariableShadowed/VariableShadowed-0.ebuild
+--- standalone/DeclarationShadowedCheck/VariableShadowed/VariableShadowed-0.ebuild
++++ fixed/DeclarationShadowedCheck/VariableShadowed/VariableShadowed-0.ebuild
+@@ -2,15 +2,12 @@ HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+ DESCRIPTION="ebuild with shadowed variables"
+ S=${WORKDIR}
+
+-VAL=
+-
+ SLOT="0"
+ LICENSE="BSD"
+-RESTRICT="!test? ( test )"
++RESTRICT="test"
+
+ RDEPEND="dev-lang/ruby"
+ DEPEND="${RDEPEND}"
+-RDEPEND="dev-ruby/stub"
++RDEPEND+="dev-ruby/stub"
+
+-RESTRICT="test"
+ VAL=5

--- a/testdata/repos/standalone/DeclarationShadowedCheck/DuplicateFunctionDefinition/DuplicateFunctionDefinition-0.ebuild
+++ b/testdata/repos/standalone/DeclarationShadowedCheck/DuplicateFunctionDefinition/DuplicateFunctionDefinition-0.ebuild
@@ -1,0 +1,21 @@
+
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+DESCRIPTION="ebuild with shadowed variables"
+SLOT="0"
+LICENSE="BSD"
+
+pkg_preinst() {
+	:
+}
+
+any_function() {
+	:
+}
+
+any_function() {
+	:
+}
+
+pkg_preinst() {
+	any_function
+}

--- a/testdata/repos/standalone/DeclarationShadowedCheck/VariableShadowed/VariableShadowed-0.ebuild
+++ b/testdata/repos/standalone/DeclarationShadowedCheck/VariableShadowed/VariableShadowed-0.ebuild
@@ -1,0 +1,16 @@
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+DESCRIPTION="ebuild with shadowed variables"
+S=${WORKDIR}
+
+VAL=
+
+SLOT="0"
+LICENSE="BSD"
+RESTRICT="!test? ( test )"
+
+RDEPEND="dev-lang/ruby"
+DEPEND="${RDEPEND}"
+RDEPEND="dev-ruby/stub"
+
+RESTRICT="test"
+VAL=5


### PR DESCRIPTION
Rules:

- Defined in global scope
- Not inside logic block (so only check top level assignments)
- Doesn't use variable append (`BDEPEND+=""`)
- Doesn't mention self variable inside (`BDEPEND="${BDEPEND} ..."`)

Resolves: https://github.com/pkgcore/pkgcheck/issues/622

- [x] Add tests