### PR TITLE
BannedEapiCommand: check for has_version --host-root

### DIFF
--- a/src/pkgcheck/checks/codingstyle.py
+++ b/src/pkgcheck/checks/codingstyle.py
@@ -91,6 +91,15 @@ class BadCommandsCheck(Check):
                     )
                 elif name in pkg.eapi.phases.values():
                     yield BannedPhaseCall(line=name, lineno=lineno + 1, pkg=pkg)
+                elif name in ("has_version", "best_version"):
+                    if not pkg.eapi.options.query_host_root and any(
+                        pkg.node_str(n) == "--host-root"
+                        for n in node.children_by_field_name("argument")
+                    ):
+                        name = f"{name} --host-root"
+                        yield BannedEapiCommand(
+                            name, line=call, lineno=lineno + 1, eapi=pkg.eapi, pkg=pkg
+                        )
 
 
 class EendMissingArg(results.LineResult, results.Warning):

--- a/testdata/data/repos/standalone/BadCommandsCheck/BannedEapiCommand/expected.json
+++ b/testdata/data/repos/standalone/BadCommandsCheck/BannedEapiCommand/expected.json
@@ -1,1 +1,3 @@
 {"__class__": "BannedEapiCommand", "category": "BadCommandsCheck", "package": "BannedEapiCommand", "version": "0", "line": "dohtml doc/*", "lineno": 9, "command": "dohtml", "eapi": "7"}
+{"__class__": "BannedEapiCommand", "category": "BadCommandsCheck", "package": "BannedEapiCommand", "version": "1", "line": "has_version --host-root stub/stub1", "lineno": 9, "command": "has_version --host-root", "eapi": "7"}
+{"__class__": "BannedEapiCommand", "category": "BadCommandsCheck", "package": "BannedEapiCommand", "version": "1", "line": "best_version --host-root stub/stub1:2", "lineno": 12, "command": "best_version --host-root", "eapi": "7"}

--- a/testdata/data/repos/standalone/BadCommandsCheck/BannedEapiCommand/fix.patch
+++ b/testdata/data/repos/standalone/BadCommandsCheck/BannedEapiCommand/fix.patch
@@ -1,6 +1,6 @@
 diff -Naur standalone/BadCommandsCheck/BannedEapiCommand/BannedEapiCommand-0.ebuild fixed/BadCommandsCheck/BannedEapiCommand/BannedEapiCommand-0.ebuild
---- standalone/BadCommandsCheck/BannedEapiCommand/BannedEapiCommand-0.ebuild	2019-10-01 15:48:21.121467232 -0600
-+++ fixed/BadCommandsCheck/BannedEapiCommand/BannedEapiCommand-0.ebuild	2019-10-01 15:50:51.970090195 -0600
+--- standalone/BadCommandsCheck/BannedEapiCommand/BannedEapiCommand-0.ebuild
++++ fixed/BadCommandsCheck/BannedEapiCommand/BannedEapiCommand-0.ebuild
 @@ -6,5 +6,6 @@
  LICENSE="BSD"
 
@@ -8,4 +8,19 @@ diff -Naur standalone/BadCommandsCheck/BannedEapiCommand/BannedEapiCommand-0.ebu
 -	dohtml doc/*
 +	docinto html
 +	dodoc doc/*
+ }
+
+diff -Naur standalone/BadCommandsCheck/BannedEapiCommand/BannedEapiCommand-1.ebuild fixed/BadCommandsCheck/BannedEapiCommand/BannedEapiCommand-1.ebuild
+--- standalone/BadCommandsCheck/BannedEapiCommand/BannedEapiCommand-1.ebuild
++++ fixed/BadCommandsCheck/BannedEapiCommand/BannedEapiCommand-1.ebuild
+@@ -6,8 +6,8 @@ SLOT="0"
+ LICENSE="BSD"
+
+ src_install() {
+-	if has_version --host-root stub/stub1; then
++	if has_version -b stub/stub1; then
+ 		:
+ 	fi
+-	H=$(best_version --host-root stub/stub1:2)
++	H=$(best_version -b stub/stub1:2)
  }

--- a/testdata/repos/standalone/BadCommandsCheck/BannedEapiCommand/BannedEapiCommand-1.ebuild
+++ b/testdata/repos/standalone/BadCommandsCheck/BannedEapiCommand/BannedEapiCommand-1.ebuild
@@ -1,0 +1,13 @@
+EAPI=7
+
+DESCRIPTION="Ebuild using banned has_version"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"
+
+src_install() {
+	if has_version --host-root stub/stub1; then
+		:
+	fi
+	H=$(best_version --host-root stub/stub1:2)
+}


### PR DESCRIPTION
Catch ``has_version --host-root`` and ``best_version --host-root`` calls, which are not allowed in EAPI>=7. Use pkgcore EAPI's option `query_host_root` which is False for EAPI>=7, so great flag for our case.

On current master I only catch:

```
net-misc/zerotier
  BannedEapiCommand: version 1.6.4: 'has_version --host-root' banned in EAPI 7, used on line 38: 'has_version --host-root "sys-devel/clang:${LLVM_SLOT}"'
  BannedEapiCommand: version 1.6.4: 'has_version --host-root' banned in EAPI 7, used on line 43: 'has_version --host-root "=sys-devel/lld-${LLVM_SLOT}*"'
```

Resolves: https://github.com/pkgcore/pkgcheck/issues/630