### PR TITLE
MissingRemoteId: MissingRemoteId: expand gitlab matching rules

### DIFF
--- a/src/pkgcheck/checks/metadata_xml.py
+++ b/src/pkgcheck/checks/metadata_xml.py
@@ -645,7 +645,9 @@ class MissingRemoteIdCheck(Check):
     _source = sources.PackageRepoSource
     known_results = frozenset([MissingRemoteId])
 
-    _gitlab_match = r"(?P<value>(\w[^/]*/)*\w[^/]*/\w[^/]*)"
+    # Exclude api groups and raw project names to conform with https://docs.gitlab.com/ee/user/reserved_names.html
+    # with the URI's which are most likely to end up in SRC_URI
+    _gitlab_match = r"(?P<value>((?!api/)\w[^/]*/)+(?!raw/)\w[^/]*)"
 
     remotes_map = (
         ("bitbucket", r"https://bitbucket.org/(?P<value>[^/]+/[^/]+)"),


### PR DESCRIPTION
* Notably handles the particular case with gitlab package hosting.

Bug: https://github.com/pkgcore/pkgcheck/issues/636