### PR TITLE
checks.git: Set tarfile filter

### DIFF
--- a/src/pkgcheck/checks/git.py
+++ b/src/pkgcheck/checks/git.py
@@ -283,6 +283,10 @@ class _RemovalRepo(UnconfiguredTree):
         if old_files.poll():
             error = old_files.stderr.read().decode().strip()
             raise PkgcheckUserException(f"failed populating archive repo: {error}")
+        # https://docs.python.org/3.12/library/tarfile.html#tarfile-extraction-filter
+        if hasattr(tarfile, "data_filter"):
+            # https://docs.python.org/3.12/library/tarfile.html#tarfile.TarFile.extraction_filter
+            tarfile.TarFile.extraction_filter = staticmethod(tarfile.data_filter)
         with tarfile.open(mode="r|", fileobj=old_files.stdout) as tar:
             tar.extractall(path=self.location)
 


### PR DESCRIPTION
* Not setting it triggers a DeprecationWarning in python3.12.
* Despite tarballs by git-archive being trusted, there isn't benefit in trusting it as the tarballs don't use metadata that would require it.