### PR TITLE
OldPackageName: new check for package named after old package name

### DIFF
--- a/testdata/data/repos/visibility/VisibilityCheck/OldPackageName/expected.json
+++ b/testdata/data/repos/visibility/VisibilityCheck/OldPackageName/expected.json
@@ -1,0 +1,1 @@
+{"__class__": "OldPackageName", "category": "VisibilityCheck", "package": "OldPackageName", "new_name": "stub/random-pkgname"}

--- a/testdata/repos/visibility/VisibilityCheck/OldPackageName/OldPackageName-0.ebuild
+++ b/testdata/repos/visibility/VisibilityCheck/OldPackageName/OldPackageName-0.ebuild
@@ -1,0 +1,6 @@
+EAPI=7
+DESCRIPTION="Ebuild with pkgmoved name"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"
+KEYWORDS="~amd64"

--- a/testdata/repos/visibility/profiles/updates/1Q-2024
+++ b/testdata/repos/visibility/profiles/updates/1Q-2024
@@ -1,1 +1,2 @@
 move stub/old-name stub/stable
+move VisibilityCheck/OldPackageName stub/random-pkgname


### PR DESCRIPTION
Resolves: https://github.com/pkgcore/pkgcheck/issues/650