### PR TITLE
docs: Add intersphinx linkage to pkgcore/snakeoil.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -324,3 +324,13 @@ epub_exclude_files = ["search.html"]
 
 # If false, no index is generated.
 # epub_use_index = True
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "chardet": ("https://chardet.readthedocs.io/en/latest", None),
+    "lazy-object-proxy": ("https://python-lazy-object-proxy.readthedocs.io/en/latest", None),
+    "setuptools": ("https://setuptools.pypa.io/en/latest", None),
+}
+intersphinx_mapping.update(
+    (x, (f"https://pkgcore.github.io/{x}", None)) for x in ("pkgcore snakeoil").split()
+)


### PR DESCRIPTION
For any references that go back into those, they're not reachable for doc rendering without this.