### PR TITLE
addons.net: suppress urllib3 import warnings

### DIFF
--- a/src/pkgcheck/addons/net.py
+++ b/src/pkgcheck/addons/net.py
@@ -2,12 +2,14 @@
 
 import logging
 import os
-
-import requests
+import warnings
 
 from ..checks.network import RequestError, SSLError
 
-# suppress all urllib3 log messages
+# suppress all urllib3 log messages and import warnings
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    import requests
 logging.getLogger("urllib3").propagate = False
 
 


### PR DESCRIPTION
Most notably, this includes NotOpenSSLWarning:
https://github.com/urllib3/urllib3/issues/3020#issuecomment-1785873825