### PR TITLE
git: fix no-copies option

### DIFF
--- a/src/pkgcheck/addons/git.py
+++ b/src/pkgcheck/addons/git.py
@@ -155,8 +155,7 @@ class _ParseGitRepo:
         cmd = shlex.split(self._git_cmd)
         cmd.append(f"--pretty=tformat:%n{'%n'.join(self._format)}")
         cmd.append(commit_range)
-        # https://bugs.gentoo.org/924718
-        # cmd.extend(("--no-find-copies", "--no-find-copies-harder", "--find-renames"))
+        cmd.extend(("--no-find-copies-harder", "--find-renames"))
 
         self.git_log = GitLog(cmd, self.path)
         # discard the initial newline


### PR DESCRIPTION
git: fix no-copies option

This reverts commit 9103513e26f9f2aeade5b563a49697c0e2665e3e.

I originally added --no-find-copies in e688357bdc5773009bb2e106075d9852f2513f89
to suppress git being too clever which ends up confusing our git integration, as
we're not really interested in copies. I was going to use --no-find-copies-harder
but I figured --no-find-copies sounded better as it was less specific and for
our purposes here, we don't want copies at all, so why not?

But --no-find-copies isn't a boolean option, it's just that until git commit
5825268db1058516d05be03d6a8d8d55eea5a943 ('parse-options: fully disable option abbreviation with PARSE_OPT_KEEP_UNKNOWN'),
it tolerated it and expanded it to --no-find-copies-harder. Oops!

Let's use --no-find-copies-harder as we originally should have, as the only
available option to control the behavior, modulo setting a similarity % threshold
with --find-copies=n.

We're fine to do this as, quoting the git-log docs:
"[...] and options applicable to the git-diff[1] command to control how the changes each commit introduces are shown."

Bug: https://bugs.gentoo.org/924718
Bug: https://github.com/pkgcore/pkgcheck/issues/663
Signed-off-by: Sam James <sam@gentoo.org>