### PR TITLE
Revert "ci: test py3.13"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,11 +19,6 @@ jobs:
         tree-sitter-bash: [bundled]
         include:
           - os: ubuntu-latest
-            python-version: '3.13-dev'
-            deps: newest-deps
-            experimental: true
-            tree-sitter-bash: bundled
-          - os: ubuntu-latest
             python-version: '3.11'
             deps: minimal-deps
             experimental: false


### PR DESCRIPTION
This reverts commit 9cb39d40ef6334961bc247edc722d893abce9985.

Temproarily disable Python 3.13 in CI as lxml isn't building anymore, even though it did until about last week...