### PR TITLE
NewerEAPIAvailable: committing new ebuilds with old EAPI

### DIFF
--- a/tests/checks/test_git.py
+++ b/tests/checks/test_git.py
@@ -38,7 +38,7 @@ class TestGitCommitMessageCheck(ReportTestCase):
     check = git_mod.GitCommitMessageCheck(options)
 
     def test_sign_offs(self):
-        # assert that it checks for both author and comitter
+        # assert that it checks for both author and committer
         r = self.assertReport(
             self.check, FakeCommit(author="user1", committer="user2", message=["blah"])
         )


### PR DESCRIPTION
Requested by @juippis, and it indeed seems useful.

Catch cases where new ebuilds are committed with old EAPIs (checks against inherited eclasses). This is checked during `--commits` stage.

Resolves: https://github.com/pkgcore/pkgcheck/issues/666