### PR TITLE
Fix crash when performing a  `scan--net --timeout 0` call to a ftp site

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
 	"pathspec",
 	"tree-sitter>=0.21.0",
 	"tree-sitter-bash>=0.21.0",
-	"snakeoil~=0.10.7",
+	"snakeoil~=0.10.8",
 	"pkgcore~=0.12.25",
 ]
 build-backend = "py_build"
@@ -46,7 +46,7 @@ dependencies = [
 	"pathspec",
 	"tree-sitter>=0.21.0",
 	"tree-sitter-bash>=0.21.0",
-	"snakeoil~=0.10.7",
+	"snakeoil~=0.10.8",
 	"pkgcore~=0.12.25",
 ]
 

--- a/src/pkgcheck/addons/__init__.py
+++ b/src/pkgcheck/addons/__init__.py
@@ -274,6 +274,16 @@ class UseAddon(base.Addon):
 class NetAddon(base.Addon):
     """Addon supporting network functionality."""
 
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        if self.options.timeout == 0:
+            # set timeout to 0 to never timeout
+            self.timeout = None
+        else:
+            # default to timing out connections after 5 seconds
+            self.timeout = self.options.timeout if self.options.timeout is not None else 5
+
     @classmethod
     def mangle_argparser(cls, parser):
         group = parser.add_argument_group("network")
@@ -291,7 +301,7 @@ class NetAddon(base.Addon):
 
             return Session(
                 concurrent=self.options.tasks,
-                timeout=self.options.timeout,
+                timeout=self.timeout,
                 user_agent=self.options.user_agent,
             )
         except ImportError as e:

--- a/src/pkgcheck/addons/net.py
+++ b/src/pkgcheck/addons/net.py
@@ -18,12 +18,7 @@ class Session(requests.Session):
 
     def __init__(self, concurrent=None, timeout=None, user_agent=None):
         super().__init__()
-        if timeout == 0:
-            # set timeout to 0 to never timeout
-            self.timeout = None
-        else:
-            # default to timing out connections after 5 seconds
-            self.timeout = timeout if timeout is not None else 5
+        self.timeout = timeout
 
         # block when urllib3 connection pool is full
         concurrent = concurrent if concurrent is not None else os.cpu_count() * 5

--- a/src/pkgcheck/checks/__init__.py
+++ b/src/pkgcheck/checks/__init__.py
@@ -127,7 +127,7 @@ class NetworkCheck(AsyncCheck, OptionalCheck):
         super().__init__(*args, **kwargs)
         if not self.options.net:
             raise SkipCheck(self, "network checks not enabled")
-        self.timeout = self.options.timeout
+        self.timeout = net_addon.timeout
         self.session = net_addon.session
 
 

--- a/tests/addons/test_addons.py
+++ b/tests/addons/test_addons.py
@@ -387,10 +387,12 @@ class TestNetAddon:
         addon = addons.NetAddon(options)
         assert isinstance(addon.session, requests.Session)
         assert addon.session.timeout == 10
+        assert addon.timeout == 10
         # a timeout of zero disables timeouts entirely
         options, _ = tool.parse_args(["scan", "--timeout", "0"])
         addon = addons.NetAddon(options)
         assert addon.session.timeout is None
+        assert addon.timeout is None
 
     def test_args(self, tool):
         options, _ = tool.parse_args(


### PR DESCRIPTION
## Problem
Pkgcheck's underlying ftplib raises an unintended `ValueError`, before establishing a connection to a ftp site, when `--timeout` is set to 0.

## Fix
Instead of 0, pkgcheck should pass `None` here. Legal timeout values are described here: https://docs.python.org/3/library/socket.html#socket.socket.settimeout
Since we now want to pass `None` regardless of the protocol if `timeout` is 0, I moved the value-handling part to `NetAddon`, which serves it both to the `Session` constructor, as well as to `NetworkCheck` and thus to `_ftp_check`.

I also modified `test_custom_timeout` to assert that `NetAddon` handles all non-negative inputs correctly. 

I'm looking forward to hearing your feedback!

##  How to Reproduce
With ::gentoo at checkout `127160ac611d39cc6bb2ca21fcf99a086fe2b176`:
```sh
$ equery m -U app-admin/chrootuid
 * app-admin/chrootuid [gentoo]
Homepage:    ftp://ftp.porcupine.org/pub/security/index.html
```

`pkgcheck scan --net -c HomepageUrlCheck --timeout 0 app-admin/chrootuid`
should not fail but it does:

```sh
pkgcheck scan: error: Traceback (most recent call last):
  File "/usr/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/venv/lib/python3.11/site-packages/pkgcheck/checks/network.py", line 168, in _ftp_check
    urllib.request.urlopen(url, timeout=self.timeout)
  File "/usr/lib/python3.11/urllib/request.py", line 216, in urlopen
    return opener.open(url, data, timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/urllib/request.py", line 519, in open
    response = self._open(req, data)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/urllib/request.py", line 536, in _open
    result = self._call_chain(self.handle_open, protocol, protocol +
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/urllib/request.py", line 496, in _call_chain
    result = func(*args)
             ^^^^^^^^^^^
  File "/usr/lib/python3.11/urllib/request.py", line 1565, in ftp_open
    fw = self.connect_ftp(user, passwd, host, port, dirs, req.timeout)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/urllib/request.py", line 1585, in connect_ftp
    return ftpwrapper(user, passwd, host, port, dirs, timeout,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/urllib/request.py", line 2413, in __init__
    self.init()
  File "/usr/lib/python3.11/urllib/request.py", line 2422, in init
    self.ftp.connect(self.host, self.port, self.timeout)
  File "/usr/lib/python3.11/ftplib.py", line 154, in connect
    raise ValueError('Non-blocking socket (timeout=0) is not supported')
ValueError: Non-blocking socket (timeout=0) is not supported
```