### PR TITLE
Permit the '@' character in filenames

### DIFF
--- a/src/pkgcheck/checks/pkgdir.py
+++ b/src/pkgcheck/checks/pkgdir.py
@@ -17,7 +17,7 @@ allowed_filename_chars = set()
 allowed_filename_chars.update(chr(x) for x in range(ord("a"), ord("z") + 1))
 allowed_filename_chars.update(chr(x) for x in range(ord("A"), ord("Z") + 1))
 allowed_filename_chars.update(chr(x) for x in range(ord("0"), ord("9") + 1))
-allowed_filename_chars.update([".", "-", "_", "+", ":"])
+allowed_filename_chars.update([".", "-", "_", "+", ":", "@"])
 
 
 class MismatchedPN(results.PackageResult, results.Error):


### PR DESCRIPTION
This will allow for systemd template units to be stored in files/ without mangling the filename.

PMS says nothing about filenames in files/ so we can really permit whatever we find palatable.
