### PR TITLE
OldPackageNameDep: check for dependency using pkgmoved name

### DIFF
--- a/testdata/data/repos/visibility/VisibilityCheck/OldPackageNameDep/expected.json
+++ b/testdata/data/repos/visibility/VisibilityCheck/OldPackageNameDep/expected.json
@@ -1,0 +1,4 @@
+{"__class__": "OldPackageNameDep", "category": "DependencyMoved", "package": "DependencyMoved", "version": "0", "attr": "bdepend", "dep": ">=stub/old-name-2.71-r6:2.71", "new_name": "stub/stable"}
+{"__class__": "OldPackageNameDep", "category": "DependencyMoved", "package": "DependencyMoved", "version": "0", "attr": "rdepend", "dep": "stub/old-name:2", "new_name": "stub/stable"}
+{"__class__": "OldPackageNameDep", "category": "DependencyMoved", "package": "DependencyMoved", "version": "0", "attr": "rdepend", "dep": "~stub/old-name-2", "new_name": "stub/stable"}
+{"__class__": "OldPackageNameDep", "category": "VisibilityCheck", "package": "OldPackageNameDep", "version": "0", "attr": "rdepend", "dep": "!VisibilityCheck/OldPackageName", "new_name": "stub/random-pkgname"}

--- a/testdata/repos/visibility/VisibilityCheck/OldPackageNameDep/OldPackageNameDep-0.ebuild
+++ b/testdata/repos/visibility/VisibilityCheck/OldPackageNameDep/OldPackageNameDep-0.ebuild
@@ -1,0 +1,8 @@
+EAPI=7
+DESCRIPTION="Ebuild with pkgmoved dep"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+SLOT="0"
+LICENSE="BSD"
+KEYWORDS="~amd64"
+
+RDEPEND="!VisibilityCheck/OldPackageName"


### PR DESCRIPTION
Results on current master. Important to note that some of them block on it's own previous name (like net-analyzer/snmpclitools). Not sure if this is fine or should be whitelisted.

```
games-action/descent1-freedata
  OldPackageNameDep: version 1: rdepend: '!games-action/d1x-rebirth' uses old package name which is source of pkgmove, rename into 'games-action/dxx-rebirth'

games-action/descent2-freedata
  OldPackageNameDep: version 1: rdepend: '!games-action/d2x-rebirth' uses old package name which is source of pkgmove, rename into 'games-action/dxx-rebirth'

games-action/dxx-rebirth
  OldPackageNameDep: version 0.61.0_pre20240630: rdepend: '!<games-action/d1x-rebirth-0.59.100' uses old package name which is source of pkgmove, rename into 'games-action/dxx-rebirth'
  OldPackageNameDep: version 0.61.0_pre20240630: rdepend: '!<games-action/d2x-rebirth-0.59.100' uses old package name which is source of pkgmove, rename into 'games-action/dxx-rebirth'
  OldPackageNameDep: version 9999: rdepend: '!<games-action/d1x-rebirth-0.59.100' uses old package name which is source of pkgmove, rename into 'games-action/dxx-rebirth'
  OldPackageNameDep: version 9999: rdepend: '!<games-action/d2x-rebirth-0.59.100' uses old package name which is source of pkgmove, rename into 'games-action/dxx-rebirth'

games-puzzle/world-of-goo-gog
  OldPackageNameDep: version 1.51.29337: rdepend: '!games-puzzle/world-of-goo' uses old package name which is source of pkgmove, rename into 'games-puzzle/world-of-goo-hb'

games-puzzle/world-of-goo-hb
  OldPackageNameDep: version 1.53: rdepend: '!games-puzzle/world-of-goo' uses old package name which is source of pkgmove, rename into 'games-puzzle/world-of-goo-hb'

net-analyzer/snmpclitools
  OldPackageNameDep: version 0.6.4-r1: rdepend: '!dev-python/pysnmp-apps' uses old package name which is source of pkgmove, rename into 'net-analyzer/snmpclitools'
```

Resolves: https://github.com/pkgcore/pkgcheck/issues/659