### PR TITLE
NonConsistentTarUsage: check tar without -f

### DIFF
--- a/testdata/data/repos/standalone/NonPosixCheck/NonConsistentTarUsage/expected.json
+++ b/testdata/data/repos/standalone/NonPosixCheck/NonConsistentTarUsage/expected.json
@@ -1,0 +1,2 @@
+{"__class__": "NonConsistentTarUsage", "category": "NonPosixCheck", "package": "NonConsistentTarUsage", "version": "0", "line": "tar -zx \"${A}\"", "lineno": 7}
+{"__class__": "NonConsistentTarUsage", "category": "NonPosixCheck", "package": "NonConsistentTarUsage", "version": "0", "line": "tar c \\\n\t\t--owner=0 \\\n\t\t--group=0 \\\n\t\t--numeric-owner \\\n\t\t-C \"${S}\" .", "lineno": 8}

--- a/testdata/data/repos/standalone/NonPosixCheck/NonConsistentTarUsage/fix.patch
+++ b/testdata/data/repos/standalone/NonPosixCheck/NonConsistentTarUsage/fix.patch
@@ -1,0 +1,13 @@
+--- standalone/NonPosixCheck/NonConsistentTarUsage/NonConsistentTarUsage-0.ebuild
++++ fixed/NonPosixCheck/NonConsistentTarUsage/NonConsistentTarUsage-0.ebuild
+@@ -4,8 +4,8 @@ LICENSE="BSD"
+ SLOT="0"
+
+ src_prepare() {
+-	tar -zx "${A}"
+-	tar c \
++	tar -zx -f - "${A}"
++	tar cf - \
+ 		--owner=0 \
+ 		--group=0 \
+ 		--numeric-owner \

--- a/testdata/repos/standalone/NonPosixCheck/NonConsistentTarUsage/NonConsistentTarUsage-0.ebuild
+++ b/testdata/repos/standalone/NonPosixCheck/NonConsistentTarUsage/NonConsistentTarUsage-0.ebuild
@@ -1,0 +1,16 @@
+DESCRIPTION="Ebuild with non posix tar usage"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+LICENSE="BSD"
+SLOT="0"
+
+src_prepare() {
+	tar -zx "${A}"
+	tar c \
+		--owner=0 \
+		--group=0 \
+		--numeric-owner \
+		-C "${S}" . | something
+	tar -c -f - -C "${S}" . | something
+	tar -c --file - -C "${S}" . | something
+	tar -c --file=- -C "${S}" . | something
+}


### PR DESCRIPTION
The ``tar`` command defaults to reading from stdin, unless this default is changed at compile time or the ``TAPE`` environment variable is set.

To ensure consistent behavior, the ``-f`` or ``--file`` option should always be given to ensure the input device is chosen explicitly.

@floppym Here is the check for the issues you found with tar :)

Results for gentoo scan:

```
$ pkgcheck scan -k NonPosixTarUsage
dev-libs/optix
  NonPosixTarUsage: version 7.4.0: line 67: non-posix usage of tar without '-f' or '--file': 'tar -zx'
  NonPosixTarUsage: version 7.5.0: line 67: non-posix usage of tar without '-f' or '--file': 'tar -zx'

games-action/descent1-data
  NonPosixTarUsage: version 1.4a-r1: line 60: non-posix usage of tar without '-f' or '--file': 'tar c \\\n\t\t--mode=u+w \\\n\t\t--ignore-case \\\n\t\t--xform=\'s:.*/::xg\' \\\n\t\t--xform=\'s:.*:\\L\\0:x\' \\\n\t\t--xform=\'s:^chaos\\.:data/missions/\\0:x\' \\\n\t\t--xform=\'s:.*\\.dem$:data/demos/\\0:x\' \\\n\t\t--xform=\'s:.*\\.(faq|pdf|txt)$:doc/\\0:x\' \\\n\t\t--xform=\'s:^[^/]+$:data/\\0:x\' \\\n\t\t--exclude="$(use doc || echo \'*.pdf\')" \\\n\t\t*.{faq,txt,pdf} **/*.{dem,hog,msn,pig}'
  NonPosixTarUsage: version 1.4a-r1: line 71: non-posix usage of tar without '-f' or '--file': 'tar x -C "${WORKDIR}"'

games-action/descent2-data
  NonPosixTarUsage: version 1.2-r1: line 75: non-posix usage of tar without '-f' or '--file': 'tar c \\\n\t\t--mode=u+w \\\n\t\t--ignore-case \\\n\t\t--xform=\'s:.*/::xg\' \\\n\t\t--xform=\'s:.*:\\L\\0:x\' \\\n\t\t--xform=\'s:^d2(-2plyr|chaos)\\.:data/missions/\\0:x\' \\\n\t\t--xform=\'s:.*\\.dem$:data/demos/\\0:x\' \\\n\t\t--xform=\'s:.*\\.(pdf|txt)$:doc/\\0:x\' \\\n\t\t--xform=\'s:^[^/]+$:data/\\0:x\' \\\n\t\t--exclude=\'d2x*\' \\\n\t\t--exclude=\'hoard.ham\' \\\n\t\t--exclude=\'panic.*\' \\\n\t\t--exclude="$(use doc || echo \'*.pdf\')" \\\n\t\t--exclude="$(use videos || echo \'*.mvl\')" \\\n\t\t*.{txt,pdf} *-h.mvl **/*.{ham,hog,mn2,pig,s11,s22}'
  NonPosixTarUsage: version 1.2-r1: line 90: non-posix usage of tar without '-f' or '--file': 'tar x -C "${WORKDIR}"'

games-action/descent2-vertigo
  NonPosixTarUsage: version 1.0-r1: line 33: non-posix usage of tar without '-f' or '--file': 'tar c \\\n\t\t--mode=u+w \\\n\t\t--ignore-case \\\n\t\t--xform=\'s:.*/::xg\' \\\n\t\t--xform=\'s:.*:\\L\\0:x\' \\\n\t\t--xform=\'s:.*\\.(hog|mn2)$:data/missions/\\0:x\' \\\n\t\t--xform=\'s:^[^/]+$:data/\\0:x\' \\\n\t\t--exclude="$(use videos || echo \'*.mvl\')" \\\n\t\t**/{hoard.ham,d2x-h.mvl,{d2x,panic}.{hog,mn2}}*'
  NonPosixTarUsage: version 1.0-r1: line 42: non-posix usage of tar without '-f' or '--file': 'tar x -C "${WORKDIR}"'

games-rpg/comi
  NonPosixTarUsage: version 1-r1: line 29: non-posix usage of tar without '-f' or '--file': 'tar c \\\n\t\t--mode=u+w \\\n\t\t--ignore-case \\\n\t\t--xform=\'s:^[^a-z]+$:\\L\\0:x\' \\\n\t\t--xform=\'s:.*:data/\\0:x\' \\\n\t\t--xform=\'s:.*\\.(pdf|txt)$:doc/\\0:x\' \\\n\t\t--xform=\'s:^doc/data/:doc/:x\' \\\n\t\t--exclude="$(use doc || echo \'*.pdf\')" \\\n\t\t--exclude-from=<(find "${WORKDIR}"/data -type f -printf "%P\\n" 2>/dev/null) \\\n\t\t*.{txt,pdf} *.la[0-9] resource*/'
  NonPosixTarUsage: version 1-r1: line 39: non-posix usage of tar without '-f' or '--file': 'tar x -C "${WORKDIR}"'

games-strategy/settlers-2-gold-data
  NonPosixTarUsage: version 0: line 46: non-posix usage of tar without '-f' or '--file': 'tar c \\\n\t\t--mode=u+w \\\n\t\t--ignore-case \\\n\t\t--xform=\'s:.*:\\U\\0:x\' \\\n\t\t--exclude-from=<(find "${S}"/ -type f -printf "%P\\n" 2>/dev/null) \\\n\t\t{DATA,GFX}/**/*.{BBM,BOB,DAT,FNT,IDX,LBM,LST,RTX,WLD}'
  NonPosixTarUsage: version 0: line 52: non-posix usage of tar without '-f' or '--file': 'tar x -C "${S}"'



```

Resolves: https://github.com/pkgcore/pkgcheck/issues/704