### PR TITLE
python: Enforce a stricted PyPI package naming policy

### DIFF
--- a/src/pkgcheck/checks/python.py
+++ b/src/pkgcheck/checks/python.py
@@ -946,5 +946,5 @@ class PythonPackageNameCheck(Check):
             return PROJECT_SYMBOL_NORMALIZE_RE.sub("-", project).lower()
 
         pypi_name = pypi_remotes[0].name
-        if normalize(pkg.package) != normalize(pypi_name):
-            yield PythonMismatchedPackageName(pypi_name.replace(".", "-"), pkg=pkg)
+        if pkg.package != normalize(pypi_name):
+            yield PythonMismatchedPackageName(normalize(pypi_name), pkg=pkg)

--- a/testdata/data/repos/python/PythonPackageNameCheck/PythonMismatchedPackageName/expected.json
+++ b/testdata/data/repos/python/PythonPackageNameCheck/PythonMismatchedPackageName/expected.json
@@ -1,1 +1,2 @@
-{"__class__": "PythonMismatchedPackageName", "category": "dev-python", "package": "PythonMismatchedPackageName1", "recommended": "MismatchedPackageName1"}
+{"__class__": "PythonMismatchedPackageName", "category": "dev-python", "package": "PythonMismatchedPackageName0", "recommended": "pythonmismatchedpackagename0"}
+{"__class__": "PythonMismatchedPackageName", "category": "dev-python", "package": "PythonMismatchedPackageName1", "recommended": "mismatchedpackagename1"}


### PR DESCRIPTION
Enforce a stricter package naming policy that requires using lowercase names and hyphens over underscores.  Once this change lands, I'll update the Python Guide as well.

Previously, the policy was to permit either forcing lowercase, or to follow upstream naming (and the name check, more liberally, was done case-insensitively), with a note to enforce consistency across different packages.  This caused twofold problems.

Firstly, not all packages ended up following the policy for consistent naming -- so we e.g. have flit-core but flit_scm, or flask but Frozen-Flask.  Part of the problem is that 1) PyPI packages themselves, particularly third-party extensions, don't follow consistent naming themselves, and 2) some PyPI packages actually get "renamed" with case and/or hyphen changes.

Secondly, this policy makes naming less predictable.  In particular, with upstream name of "flit-scm", you don't immediately figure out it's "flit_scm" in Gentoo, or with "PyGithub" you can't guess whether to look for "PyGithub" or "pygithub".

The changed policy will require changes to 44 packages in Gentoo.

CC @gentoo/python