### PR TITLE
eclass: Updates for Rust checks

### DIFF
--- a/src/pkgcheck/checks/eclass.py
+++ b/src/pkgcheck/checks/eclass.py
@@ -516,9 +516,9 @@ class RubyMissingDeps(results.VersionResult, results.Warning):
 
 
 class RustMissingDeps(results.VersionResult, results.Warning):
-    """Package sets ``CARGO_OPTIONAL`` but does not use ``${RUST_DEPEND}``."""
+    """Package sets ``RUST_OPTIONAL`` but does not use ``${RUST_DEPEND}``."""
 
-    desc = "sets CARGO_OPTIONAL but does not use ${RUST_DEPEND}"
+    desc = "sets RUST_OPTIONAL (or CARGO_OPTIONAL) but does not use ${RUST_DEPEND}"
 
 
 class TmpfilesMissingDeps(results.VersionResult, results.Warning):
@@ -543,6 +543,7 @@ class EclassManualDepsCheck(Check):
     dependencies = (
         # eclass, variable, one of deps, class
         ("cargo", "CARGO_OPTIONAL", {"dev-lang/rust", "dev-lang/rust-bin"}, RustMissingDeps),
+        ("rust", "RUST_OPTIONAL", {"dev-lang/rust", "dev-lang/rust-bin"}, RustMissingDeps),
         ("go-module", "GO_OPTIONAL", {"dev-lang/go"}, GoMissingDeps),
         (
             "ruby-ng",

--- a/src/pkgcheck/checks/eclass.py
+++ b/src/pkgcheck/checks/eclass.py
@@ -516,9 +516,9 @@ class RubyMissingDeps(results.VersionResult, results.Warning):
 
 
 class RustMissingDeps(results.VersionResult, results.Warning):
-    """Package sets ``CARGO_OPTIONAL`` but does not depend on ``virtual/rust``."""
+    """Package sets ``CARGO_OPTIONAL`` but does not use ``${RUST_DEPEND}``."""
 
-    desc = "sets CARGO_OPTIONAL but does not depend on virtual/rust"
+    desc = "sets CARGO_OPTIONAL but does not use ${RUST_DEPEND}"
 
 
 class TmpfilesMissingDeps(results.VersionResult, results.Warning):
@@ -542,7 +542,7 @@ class EclassManualDepsCheck(Check):
 
     dependencies = (
         # eclass, variable, one of deps, class
-        ("cargo", "CARGO_OPTIONAL", {"virtual/rust"}, RustMissingDeps),
+        ("cargo", "CARGO_OPTIONAL", {"dev-lang/rust", "dev-lang/rust-bin"}, RustMissingDeps),
         ("go-module", "GO_OPTIONAL", {"dev-lang/go"}, GoMissingDeps),
         (
             "ruby-ng",

--- a/testdata/data/repos/standalone/EclassManualDepsCheck/RustMissingDeps/expected.json
+++ b/testdata/data/repos/standalone/EclassManualDepsCheck/RustMissingDeps/expected.json
@@ -1,1 +1,3 @@
 {"__class__": "RustMissingDeps", "category": "EclassManualDepsCheck", "package": "RustMissingDeps", "version": "1"}
+{"__class__": "RustMissingDeps", "category": "EclassManualDepsCheck", "package": "RustMissingDeps", "version": "3"}
+{"__class__": "RustMissingDeps", "category": "EclassManualDepsCheck", "package": "RustMissingDeps", "version": "4"}

--- a/testdata/data/repos/standalone/EclassManualDepsCheck/RustMissingDeps/fix.patch
+++ b/testdata/data/repos/standalone/EclassManualDepsCheck/RustMissingDeps/fix.patch
@@ -6,4 +6,4 @@ diff -Naur standalone/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-1.eb
  LICENSE="BSD"
  SLOT="0"
 +
-+BDEPEND="virtual/rust"
++BDEPEND="${RUST_DEPEND}"

--- a/testdata/data/repos/standalone/EclassManualDepsCheck/RustMissingDeps/fix.patch
+++ b/testdata/data/repos/standalone/EclassManualDepsCheck/RustMissingDeps/fix.patch
@@ -7,3 +7,21 @@ diff -Naur standalone/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-1.eb
  SLOT="0"
 +
 +BDEPEND="${RUST_DEPEND}"
+diff -Naur standalone/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-3.ebuild fixed/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-3.ebuild
+--- standalone/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-3.ebuild
++++ fixed/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-3.ebuild
+@@ -8,3 +8,5 @@ DESCRIPTION="Optional inherit without deps"
+ HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+ LICENSE="BSD"
+ SLOT="0"
++
++BDEPEND="${RUST_DEPEND}"
+diff -Naur standalone/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-4.ebuild fixed/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-4.ebuild
+--- standalone/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-4.ebuild
++++ fixed/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-4.ebuild
+@@ -8,3 +8,5 @@ DESCRIPTION="Optional inherit without deps"
+ HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+ LICENSE="BSD"
+ SLOT="0"
++
++BDEPEND="${RUST_DEPEND}"

--- a/testdata/repos/standalone/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-2.ebuild
+++ b/testdata/repos/standalone/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-2.ebuild
@@ -1,0 +1,6 @@
+inherit rust
+
+DESCRIPTION="Normal non-optional inherit"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+LICENSE="BSD"
+SLOT="0"

--- a/testdata/repos/standalone/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-3.ebuild
+++ b/testdata/repos/standalone/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-3.ebuild
@@ -1,0 +1,10 @@
+EAPI=7
+
+RUST_OPTIONAL=1
+
+inherit rust
+
+DESCRIPTION="Optional inherit without deps"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+LICENSE="BSD"
+SLOT="0"

--- a/testdata/repos/standalone/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-4.ebuild
+++ b/testdata/repos/standalone/EclassManualDepsCheck/RustMissingDeps/RustMissingDeps-4.ebuild
@@ -1,0 +1,10 @@
+EAPI=7
+
+RUST_OPTIONAL=1
+
+inherit cargo
+
+DESCRIPTION="Optional inherit without deps"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+LICENSE="BSD"
+SLOT="0"

--- a/testdata/repos/standalone/dev-lang/rust-bin/rust-bin-1.81.0.ebuild
+++ b/testdata/repos/standalone/dev-lang/rust-bin/rust-bin-1.81.0.ebuild
@@ -1,0 +1,4 @@
+DESCRIPTION="Stub ebuild"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+LICENSE="BSD"
+SLOT="${PV}"

--- a/testdata/repos/standalone/dev-lang/rust-bin/rust-bin-1.82.0.ebuild
+++ b/testdata/repos/standalone/dev-lang/rust-bin/rust-bin-1.82.0.ebuild
@@ -1,0 +1,4 @@
+DESCRIPTION="Stub ebuild"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+LICENSE="BSD"
+SLOT="${PV}"

--- a/testdata/repos/standalone/dev-lang/rust/rust-1.81.0.ebuild
+++ b/testdata/repos/standalone/dev-lang/rust/rust-1.81.0.ebuild
@@ -1,0 +1,4 @@
+DESCRIPTION="Stub ebuild"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+LICENSE="BSD"
+SLOT="${PV}"

--- a/testdata/repos/standalone/dev-lang/rust/rust-1.82.0.ebuild
+++ b/testdata/repos/standalone/dev-lang/rust/rust-1.82.0.ebuild
@@ -1,0 +1,4 @@
+DESCRIPTION="Stub ebuild"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+LICENSE="BSD"
+SLOT="${PV}"

--- a/testdata/repos/standalone/eclass/cargo.eclass
+++ b/testdata/repos/standalone/eclass/cargo.eclass
@@ -1,5 +1,7 @@
 # cargo eclass
 
+inherit rust
+
 CARGO_CRATE_URIS=${CRATES}
 
 cargo_crate_uris() { :; }

--- a/testdata/repos/standalone/eclass/cargo.eclass
+++ b/testdata/repos/standalone/eclass/cargo.eclass
@@ -1,5 +1,9 @@
 # cargo eclass
 
+if [[ -n ${CARGO_OPTIONAL} ]]; then
+	RUST_OPTIONAL=1
+fi
+
 inherit rust
 
 CARGO_CRATE_URIS=${CRATES}

--- a/testdata/repos/standalone/eclass/rust.eclass
+++ b/testdata/repos/standalone/eclass/rust.eclass
@@ -1,0 +1,10 @@
+# rust eclass
+
+RUST_DEPEND="
+	|| (
+		dev-lang/rust-bin:1.82.0
+		dev-lang/rust:1.82.0
+		dev-lang/rust-bin:1.81.0
+		dev-lang/rust:1.81.0
+	)
+"

--- a/testdata/repos/standalone/virtual/rust/rust-0.ebuild
+++ b/testdata/repos/standalone/virtual/rust/rust-0.ebuild
@@ -1,2 +1,0 @@
-DESCRIPTION="Stub ebuild"
-SLOT="0"


### PR DESCRIPTION
Support for new `${RUST_DEPEND}` value, `RUST_OPTIONAL` and `rust` eclass inherit.