### PR TITLE
OutdatedBlocker: update from 2 years -> 4 years

### DIFF
--- a/src/pkgcheck/checks/metadata.py
+++ b/src/pkgcheck/checks/metadata.py
@@ -995,7 +995,7 @@ class DependencyCheck(Check):
 
 
 class OutdatedBlocker(results.VersionResult, results.Info):
-    """Blocker dependency removed at least two years ago from the tree.
+    """Blocker dependency removed at least four years ago from the tree.
 
     Note that this ignores slot/subslot deps and USE deps in blocker atoms.
     """
@@ -1061,7 +1061,7 @@ class OutdatedBlockersCheck(Check):
                         removal = max(x.time for x in matches)
                         removal = datetime.fromtimestamp(removal)
                         years = (self.today - removal).days / 365
-                        if years >= 2:
+                        if years >= 4:
                             outdated_blockers[attr].add((atom, round(years, 2)))
                     else:
                         nonexistent_blockers[attr].add(atom)

--- a/tests/checks/test_metadata.py
+++ b/tests/checks/test_metadata.py
@@ -1098,8 +1098,8 @@ class TestOutdatedBlockersCheck(misc.ReportTestCase):
             self.init_check(future=days)
             self.assertNoReport(self.check, self.source)
 
-        # blocker was removed at least 2 years ago
-        for days, years in ((730, 2), (1825, 5)):
+        # blocker was removed at least 4 years ago
+        for days, years in ((1460, 4), (1825, 5)):
             self.init_check(future=days)
             r = self.assertReport(self.check, self.source)
             expected = metadata.OutdatedBlocker(


### PR DESCRIPTION
2 years is too aggressive IMHO. See de65ca7b4a3f3a68b65b56e2dcaf6e511d3a3443 for a recent example of this in ::gentoo but there's been plenty of such cases in #gentoo on IRC where we got users upgrading fine but they became unstuck by a removed blocker.

Such blockers are really cheap and the purpose of the warning is really to remove ancient cruft rather than actually obstruct people upgrading systems where it's viable.

Note that it's especially problematic because of the current behaviour of python-exec where emerge won't be able to resume if python-exec got updated but portage hasn't yet been rebuilt w/ new PYTHON_TARGETS.

(... because if any interruption occurs, it can be fatal.)

Bug: https://bugs.gentoo.org/916498