### PR TITLE
tests: Wrap partial() in staticmethod(), in attributes for py3.14

### DIFF
--- a/tests/scripts/test_pkgcheck.py
+++ b/tests/scripts/test_pkgcheck.py
@@ -9,7 +9,7 @@ from pkgcheck.scripts import run
 
 def test_script_run(capsys):
     """Test regular code path for running scripts."""
-    script = partial(run, project)
+    script = staticmethod(partial(run, project))
 
     with patch(f"{project}.scripts.import_module") as import_module:
         import_module.side_effect = ImportError("baz module doesn't exist")
@@ -40,7 +40,7 @@ def test_script_run(capsys):
 
 
 class TestPkgcheck:
-    script = partial(run, project)
+    script = staticmethod(partial(run, project))
 
     def test_version(self, capsys):
         with patch("sys.argv", [project, "--version"]):

--- a/tests/scripts/test_pkgcheck_cache.py
+++ b/tests/scripts/test_pkgcheck_cache.py
@@ -8,7 +8,7 @@ from pkgcheck.scripts import run
 
 
 class TestPkgcheckCache:
-    script = partial(run, project)
+    script = staticmethod(partial(run, project))
 
     @pytest.fixture(autouse=True)
     def _setup(self, testconfig, tmp_path):

--- a/tests/scripts/test_pkgcheck_ci.py
+++ b/tests/scripts/test_pkgcheck_ci.py
@@ -9,7 +9,7 @@ from pkgcore.ebuild.cpv import VersionedCPV
 
 
 class TestPkgcheckCi:
-    script = partial(run, "pkgcheck")
+    script = staticmethod(partial(run, "pkgcheck"))
 
     @pytest.fixture(autouse=True)
     def _setup(self, testconfig, tmp_path):

--- a/tests/scripts/test_pkgcheck_show.py
+++ b/tests/scripts/test_pkgcheck_show.py
@@ -10,7 +10,7 @@ from pkgcheck.scripts import run
 
 
 class TestPkgcheckShow:
-    script = partial(run, project)
+    script = staticmethod(partial(run, project))
 
     @pytest.fixture(autouse=True)
     def _setup(self, testconfig):


### PR DESCRIPTION
Wrap `partial()` uses in class attributes in `staticmethod()`, as required for them to work correctly in Python 3.14.

> functools.partial is now a method descriptor. Wrap it in staticmethod()
> if you want to preserve the old behavior.

(https://docs.python.org/3.14/whatsnew/3.14.html#changes-in-the-python-api)