### PR TITLE
Replace p7zip with 7zip for .7z files

### DIFF
--- a/src/pkgcheck/checks/metadata.py
+++ b/src/pkgcheck/checks/metadata.py
@@ -1723,7 +1723,7 @@ class MissingUnpackerDepCheck(Check):
     non_system_unpackers = ImmutableDict(
         {
             ".zip": frozenset(["app-arch/unzip"]),
-            ".7z": frozenset(["app-arch/p7zip"]),
+            ".7z": frozenset(["app-arch/7zip"]),
             ".rar": frozenset(["app-arch/rar", "app-arch/unrar"]),
             ".lha": frozenset(["app-arch/lha"]),
             ".lzh": frozenset(["app-arch/lha"]),

--- a/tests/checks/test_metadata.py
+++ b/tests/checks/test_metadata.py
@@ -1378,4 +1378,4 @@ class TestMissingUnpackerDepCheck(use_based(), misc.ReportTestCase):
         )
         assert isinstance(r, metadata.MissingUnpackerDep)
         assert r.filenames == (f"diffball-2.7.1.7z",)
-        assert r.unpackers == ("app-arch/p7zip",)
+        assert r.unpackers == ("app-arch/7zip",)


### PR DESCRIPTION
P7zip was a fork of 7zip from a time when 7zip was windows only. Since then 7zip got official Linux support and work on p7zip stopped. At this point p7zip is old and outdated and may or may not be vulnerable. (See notice on the official Gentoo wiki)

Last year I filed a bug about this on the Gentoo bug tracker which is currently being worked on.
I think it is somewhat counter productive to tell people to require p7zip when there is active work to replace it.

https://wiki.gentoo.org/index.php?title=P7zip&oldid=1306559
https://bugs.gentoo.org/942397