### PR TITLE
Add a check for clobbered packages in overlays

### DIFF
--- a/testdata/data/repos/overlay/MasterPackageClobberedCheck/MasterPackageClobbered/expected.json
+++ b/testdata/data/repos/overlay/MasterPackageClobberedCheck/MasterPackageClobbered/expected.json
@@ -1,0 +1,1 @@
+{"__class__": "MasterPackageClobbered", "category": "MasterPackageClobberedCheck", "package": "MasterPackageClobbered", "repository": "overlayed"}

--- a/testdata/repos/overlay/MasterPackageClobberedCheck/MasterPackageClobbered/MasterPackageClobbered-1.ebuild
+++ b/testdata/repos/overlay/MasterPackageClobberedCheck/MasterPackageClobbered/MasterPackageClobbered-1.ebuild
@@ -1,0 +1,4 @@
+DESCRIPTION="Ebuild clobbered by overlay"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+LICENSE="BSD"
+SLOT="0"

--- a/testdata/repos/overlay/MasterPackageClobberedCheck/MasterPackageClobberedMasked/MasterPackageClobberedMasked-1.ebuild
+++ b/testdata/repos/overlay/MasterPackageClobberedCheck/MasterPackageClobberedMasked/MasterPackageClobberedMasked-1.ebuild
@@ -1,0 +1,4 @@
+DESCRIPTION="Ebuild clobbered by overlay"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+LICENSE="BSD"
+SLOT="0"

--- a/testdata/repos/overlay/profiles/categories
+++ b/testdata/repos/overlay/profiles/categories
@@ -1,2 +1,3 @@
+MasterPackageClobberedCheck
 UnusedInMastersCheck
 VisibilityCheck

--- a/testdata/repos/overlayed/MasterPackageClobberedCheck/MasterPackageClobbered/MasterPackageClobbered-0.ebuild
+++ b/testdata/repos/overlayed/MasterPackageClobberedCheck/MasterPackageClobbered/MasterPackageClobbered-0.ebuild
@@ -1,0 +1,4 @@
+DESCRIPTION="Ebuild clobbered by overlay"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+LICENSE="BSD"
+SLOT="0"

--- a/testdata/repos/overlayed/MasterPackageClobberedCheck/MasterPackageClobberedMasked/MasterPackageClobberedMasked-0.ebuild
+++ b/testdata/repos/overlayed/MasterPackageClobberedCheck/MasterPackageClobberedMasked/MasterPackageClobberedMasked-0.ebuild
@@ -1,0 +1,4 @@
+DESCRIPTION="Ebuild clobbered by overlay"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+LICENSE="BSD"
+SLOT="0"

--- a/testdata/repos/overlayed/profiles/categories
+++ b/testdata/repos/overlayed/profiles/categories
@@ -1,1 +1,2 @@
+MasterPackageClobberedCheck
 stub

--- a/testdata/repos/overlayed/profiles/package.mask
+++ b/testdata/repos/overlayed/profiles/package.mask
@@ -1,1 +1,4 @@
 stub/masked
+
+# Package being moved to ::overlay.
+<MasterPackageClobberedCheck/MasterPackageClobberedMasked-1


### PR DESCRIPTION
Add a check that reports if a given package clobbers a package from the master repository.  Since this only applies to some repositores (e.g. ::guru), it is optional (disabled by default).

Closes: https://github.com/pkgcore/pkgcheck/issues/745