### PR TITLE
python: Allow use of PYTHON_SINGLE_USEDEP in python_has_version

### DIFF
--- a/src/pkgcheck/checks/python.py
+++ b/src/pkgcheck/checks/python.py
@@ -33,7 +33,7 @@ PYPI_WHEEL_URI_RE = re.compile(
     re.escape(PYPI_URI_PREFIX) + r"(?P<pytag>[^/]+)/[^/]/(?P<package>[^/]+)/"
     r"(?P<fn_package>[^/-]+)-(?P<version>[^/-]+)-(?P=pytag)-(?P<abitag>[^/]+)\.whl$"
 )
-USE_FLAGS_PYTHON_USEDEP = re.compile(r"\[(.+,)?\$\{PYTHON_USEDEP\}(,.+)?\]$")
+USE_FLAGS_PYTHON_USEDEP = re.compile(r"\[(.+,)?\$\{PYTHON_(SINGLE_)?USEDEP\}(,.+)?\]$")
 
 PROJECT_SYMBOL_NORMALIZE_RE = re.compile(r"[-_.]+")
 
@@ -168,20 +168,18 @@ class PythonHasVersionUsage(results.LinesResult, results.Style):
 
 class PythonHasVersionMissingPythonUseDep(results.LineResult, results.Error):
     """Package calls ``python_has_version`` or ``has_version`` without
-    ``[${PYTHON_USEDEP}]`` suffix.
+    ``[${PYTHON_USEDEP}]`` or ``[${PYTHON_SINGLE_USEDEP}]`` suffix.
 
     All calls  to ``python_has_version`` or ``has_version`` inside
-    ``python_check_deps`` should contain ``[${PYTHON_USEDEP}]`` suffix for the
-    dependency argument [#]_.
+    ``python_check_deps`` should contain ``[${PYTHON_USEDEP}]`` or ``[${PYTHON_SINGLE_USEDEP}]``
+    suffix for the dependency argument [#]_.
 
     .. [#] https://projects.gentoo.org/python/guide/any.html#dependencies
     """
 
     @property
     def desc(self):
-        return (
-            f"line: {self.lineno}: missing [${{PYTHON_USEDEP}}] suffix for argument {self.line!r}"
-        )
+        return f"line: {self.lineno}: missing [${{PYTHON_USEDEP}}] or [${{PYTHON_SINGLE_USEDEP}}] suffix for argument {self.line!r}"
 
 
 class PythonAnyMismatchedUseHasVersionCheck(results.VersionResult, results.Warning):

--- a/testdata/repos/python/PythonCheck/PythonHasVersionUsage/PythonHasVersionUsage-2.ebuild
+++ b/testdata/repos/python/PythonCheck/PythonHasVersionUsage/PythonHasVersionUsage-2.ebuild
@@ -1,0 +1,25 @@
+# Copyright 2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( pypy3.11 python3_10 )
+
+inherit python-any-r1
+
+DESCRIPTION="Ebuild that uses has_version with PYTHON_SINGLE_USEDEP"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+
+LICENSE="BSD"
+SLOT="0"
+
+DEPEND="${PYTHON_DEPS}"
+BDEPEND="${PYTHON_DEPS}
+	$(python_gen_any_dep '
+		dev-util/babeltrace:2[python,${PYTHON_SINGLE_USEDEP}]
+	')
+"
+
+python_check_deps() {
+	python_has_version -b "dev-util/babeltrace:2[python,${PYTHON_SINGLE_USEDEP}]"
+}


### PR DESCRIPTION
https://devmanual.gentoo.org/eclass-reference/python-r1.eclass/index.html

> python_gen_any_dep [<dependency-block> [<impl-pattern>...]]
> Generate an any-of dependency that enforces a version match between the Python interpreter and Python packages. <dependency-block> may list one or more dependencies with verbatim '${PYTHON_USEDEP}' or '${PYTHON_SINGLE_USEDEP}' references (quoted!) that will get expanded inside the function. If <dependency-block> is an empty string (or no arguments are passed), a pure dependency on any Python interpreter will be generated.

```
    Example use: BDEPEND="$(python_gen_any_dep '         dev-python/foo[${PYTHON_SINGLE_USEDEP}]
            || ( dev-python/bar[${PYTHON_USEDEP}]
                    dev-python/baz[${PYTHON_USEDEP}] )' -2)"

    python_check_deps() {         python_has_version "dev-python/foo[${PYTHON_SINGLE_USEDEP}]" &&
                    { python_has_version "dev-python/bar[${PYTHON_USEDEP}]" ||
                            python_has_version "dev-python/baz[${PYTHON_USEDEP}]"; }
    } 
```