### PR TITLE
Fix `MisplacedEPyTestVar` check with no `distutils_enable_tests`

### DIFF
--- a/src/pkgcheck/checks/python.py
+++ b/src/pkgcheck/checks/python.py
@@ -441,6 +441,7 @@ class PythonCheck(Check):
     def check_epytest_vars(self, pkg):
         """Check for incorrect use of EPYTEST_* variables"""
         # TODO: do we want to check for multiple det calls? Quite unlikely.
+        det_lineno = None
         for node in pkg.global_query(bash.cmd_query):
             name = pkg.node_str(node.child_by_field_name("name"))
             if name != "distutils_enable_tests":
@@ -454,8 +455,9 @@ class PythonCheck(Check):
                     break
                 elif argument != "\\":
                     return
-            else:
-                return
+
+        if det_lineno is None:
+            return
 
         for var_name, var_node in self._get_all_global_assignments(pkg):
             # While not all variables affect distutils_enable_tests, make it

--- a/testdata/repos/python/PythonCheck/MisplacedEPyTestVar/MisplacedEPyTestVar-1.ebuild
+++ b/testdata/repos/python/PythonCheck/MisplacedEPyTestVar/MisplacedEPyTestVar-1.ebuild
@@ -1,0 +1,29 @@
+EAPI=8
+
+DISTUTILS_USE_PEP517=flit
+PYTHON_COMPAT=( python3_10 )
+
+inherit distutils-r1
+
+DESCRIPTION="Ebuild with misplaced EPYTEST vars"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+LICENSE="BSD"
+SLOT="0"
+
+EPYTEST_PLUGIN_AUTOLOAD=1
+EPYTEST_PLUGINS=( foo bar baz )
+EPYTEST_XDIST=1
+: ${EPYTEST_TIMEOUT:=180}
+
+EPYTEST_DESELECT=(
+	tests/test_foo.py::test_foo
+)
+EPYTEST_IGNORE=(
+	tests/test_bar.py
+)
+
+python_test() {
+	: ${EPYTEST_TIMEOUT:=300}
+	local EPYTEST_PLUGINS=( "${EPYTEST_PLUGINS[@]}" more )
+	EPYTEST_XDIST= epytest
+}


### PR DESCRIPTION
Reported by @parona-source.