### PR TITLE
eclass: add ShadowedEclassPhase for multiple-eclass defined phases

### DIFF
--- a/testdata/data/repos/eclass/EclassUsageCheck/ShadowedEclassPhase/expected.json
+++ b/testdata/data/repos/eclass/EclassUsageCheck/ShadowedEclassPhase/expected.json
@@ -1,0 +1,1 @@
+{"__class__": "ShadowedEclassPhase", "category": "EclassUsageCheck", "package": "ShadowedEclassPhase", "version": "0", "phase": "src_prepare", "providers": ["another-src_prepare", "export-funcs-before-inherit"]}

--- a/testdata/data/repos/eclass/EclassUsageCheck/ShadowedEclassPhase/fix.patch
+++ b/testdata/data/repos/eclass/EclassUsageCheck/ShadowedEclassPhase/fix.patch
@@ -1,0 +1,12 @@
+--- eclass/EclassUsageCheck/ShadowedEclassPhase/ShadowedEclassPhase-0.ebuild
++++ fixed/EclassUsageCheck/ShadowedEclassPhase/ShadowedEclassPhase-0.ebuild
+@@ -4,3 +4,9 @@ DESCRIPTION="Ebuild"
+ HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+ LICENSE="BSD"
+ SLOT="0"
++
++src_prepare() {
++	default
++	another-src_prepare_src_prepare
++	export-funcs-before-inherit_src_prepare
++}

--- a/testdata/repos/eclass/EclassUsageCheck/ShadowedEclassPhase/ShadowedEclassPhase-0.ebuild
+++ b/testdata/repos/eclass/EclassUsageCheck/ShadowedEclassPhase/ShadowedEclassPhase-0.ebuild
@@ -1,0 +1,6 @@
+EAPI=7
+inherit another-src_prepare export-funcs-before-inherit
+DESCRIPTION="Ebuild"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+LICENSE="BSD"
+SLOT="0"


### PR DESCRIPTION
Detect the basic case of an ignored eclass phase where two eclasses are
inherited, both defining the same phase, and the ebuild does not define
a custom implementation of that phase at all. This means one of the exported
phases from the eclasses is being ignored.

Ignore some eclasses with a blacklist where they are known to vary their
API by EAPI or eclass variables, at least for now, because the eclass
cache we have accessible here isn't keyed by EAPI or the context of the
sourcing ebuild.

Bug: https://bugs.gentoo.org/516014
Bug: https://bugs.gentoo.org/795006
Closes: https://github.com/pkgcore/pkgcheck/issues/377
Signed-off-by: Sam James <sam@gentoo.org>