### PR TITLE
addons: Add ** to special arches

### DIFF
--- a/src/pkgcheck/addons/__init__.py
+++ b/src/pkgcheck/addons/__init__.py
@@ -88,7 +88,7 @@ class KeywordsAddon(base.Addon):
 
     def __init__(self, *args):
         super().__init__(*args)
-        special = {"-*"}
+        special = {"-*", "**"}
         self.arches: frozenset[str] = self.options.target_repo.known_arches
         unstable = {"~" + x for x in self.arches}
         disabled = {"-" + x for x in chain(self.arches, unstable)}


### PR DESCRIPTION
Per [1], ** is a valid keyword that can be used in pacakge.accept_keywords. Add it to the valid list so UnknownProfilePackageKeywords is not raised when using ** in a package.accept_keywords.


[1]:https://github.com/pkgcore/pkgcore/blob/5e6487199efa52dd929fe220bf7ee86244bcb7eb/src/pkgcore/ebuild/domain.py#L589