### PR TITLE
PythonPackageNameCheck: fix TypeError on empty PyPi remote

### DIFF
--- a/src/pkgcheck/checks/python.py
+++ b/src/pkgcheck/checks/python.py
@@ -1102,6 +1102,12 @@ class PythonPackageNameCheck(Check):
         if len(pypi_remotes) != 1:
             return
 
+        pypi_name = pypi_remotes[0].name
+
+        # skip empty remotes
+        if pypi_name is None:
+            return
+
         def normalize(project: str) -> str:
             """
             Normalize project name using PEP 503 rules
@@ -1110,6 +1116,5 @@ class PythonPackageNameCheck(Check):
             """
             return PROJECT_SYMBOL_NORMALIZE_RE.sub("-", project).lower()
 
-        pypi_name = pypi_remotes[0].name
         if pkg.package != normalize(pypi_name):
             yield PythonMismatchedPackageName(normalize(pypi_name), pkg=pkg)

--- a/testdata/repos/python/dev-python/PythonMismatchedPackageName4/PythonMismatchedPackageName4-0.ebuild
+++ b/testdata/repos/python/dev-python/PythonMismatchedPackageName4/PythonMismatchedPackageName4-0.ebuild
@@ -1,0 +1,9 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Ebuild with empty PyPi remote-id in metadata.xml"
+HOMEPAGE="https://github.com/pkgcore/pkgcheck"
+LICENSE="BSD"
+SLOT="0"

--- a/testdata/repos/python/dev-python/PythonMismatchedPackageName4/metadata.xml
+++ b/testdata/repos/python/dev-python/PythonMismatchedPackageName4/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<upstream>
+		<remote-id type="pypi"></remote-id>
+	</upstream>
+</pkgmetadata>


### PR DESCRIPTION
Skip check when the PyPI `remote-id` in `metadata.xml` is empty and add a test package.

Addresses the following crash observed with a template `metadata.xml` (`<remote-id type="pypi"></remote-id>`):

```
$ pkgcheck scan .
pkgcheck scan: error: Traceback (most recent call last):
  File "/usr/lib/python3.14/site-packages/pkgcheck/pipeline.py", line 191, in _run_checks
    if results := sorted(
                  ~~~~~~^
        chain.from_iterable(pipes[i][-1][scope][j].run(restrict) for j in runners)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ):
    ^
  File "/usr/lib/python3.14/site-packages/pkgcheck/runners.py", line 71, in run
    yield from check.feed(item)
  File "/usr/lib/python3.14/site-packages/pkgcheck/checks/python.py", line 1114, in feed
    if pkg.package != normalize(pypi_name):
                      ~~~~~~~~~^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/pkgcheck/checks/python.py", line 1111, in normalize
    return PROJECT_SYMBOL_NORMALIZE_RE.sub("-", project).lower()
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'NoneType'
```

Expected result:
```
PkgMetadataXmlEmptyElement: metadata.xml: empty element 'remote-id' on line 9
```

The test is primarily a regression test, for which I could find no precedent. `python/dev-python/PythonMismatchedPackageName4` seems a bit out of place. Should I drop it, put it elsewhere, ...?