### PR TITLE
pkgcheck_scan: fix typo in help message

### DIFF
--- a/src/pkgcheck/scripts/pkgcheck_scan.py
+++ b/src/pkgcheck/scripts/pkgcheck_scan.py
@@ -50,7 +50,7 @@ scan.add_argument(
     metavar="TARGET",
     nargs="*",
     action=arghparse.ParseNonblockingStdin,
-    help="if not given, scan the repo.  If given, limit scans to pkgs matching extended atom syntax.  If no packaages match, no scans are ran",
+    help="if not given, scan the repo.  If given, limit scans to pkgs matching extended atom syntax.  If no packages match, no scans are ran",
 )
 
 main_options = scan.add_argument_group("main options")


### PR DESCRIPTION
just a small fix for the documentation